### PR TITLE
Return better message on missing api key

### DIFF
--- a/backend/core/domain/exceptions.py
+++ b/backend/core/domain/exceptions.py
@@ -152,11 +152,29 @@ class NoProviderSupportingModelError(DefaultError):
     default_message = "No configured providers support model"
     code = "no_provider_supporting_model"
 
-    def __init__(self, model: str, available_providers: list[str] | None = None):
-        super().__init__(details={"model": model, "available_providers": available_providers})
+    def __init__(
+        self,
+        model: str,
+        configured_providers: list[Provider],
+        possible_providers: list[tuple[Provider, list[str]]],
+    ):
+        message = f"""There are no configured provider supporting model '{model}'.
+You can either configure them through the UI at `{ANOTHERAI_APP_URL}/providers` or by setting
+the correct environment variables.
+The possible providers and their associated environment variables are:
+- {"\n- ".join(f"{p.value} ({', '.join(env_vars)})" for p, env_vars in possible_providers)}"""
+        super().__init__(
+            message,
+            details={
+                "model": model,
+                "configured_providers": configured_providers,
+                "possible_providers": possible_providers,
+            },
+        )
 
         self.model = model
-        self.available_providers = available_providers
+        self.configured_providers = configured_providers
+        self.possible_providers = possible_providers
 
 
 class SunsetModelWithoutReplacementError(Exception):

--- a/backend/core/providers/anthropic/anthropic_provider_test.py
+++ b/backend/core/providers/anthropic/anthropic_provider_test.py
@@ -434,15 +434,13 @@ class TestSingleStream:
 
 
 class TestComplete:
-    async def test_complete_pdf(self, httpx_mock: HTTPXMock):
+    async def test_complete_pdf(self, httpx_mock: HTTPXMock, anthropic_provider: AnthropicProvider):
         httpx_mock.add_response(
             url="https://api.anthropic.com/v1/messages",
             json=fixtures_json("anthropic", "completion.json"),
         )
 
-        provider = AnthropicProvider()
-
-        o = await provider.complete(
+        o = await anthropic_provider.complete(
             [
                 Message(
                     role="user",
@@ -487,15 +485,13 @@ class TestComplete:
             },
         )
 
-    async def test_complete_image(self, httpx_mock: HTTPXMock):
+    async def test_complete_image(self, httpx_mock: HTTPXMock, anthropic_provider: AnthropicProvider):
         httpx_mock.add_response(
             url="https://api.anthropic.com/v1/messages",
             json=fixtures_json("anthropic", "completion.json"),
         )
 
-        provider = AnthropicProvider()
-
-        o = await provider.complete(
+        o = await anthropic_provider.complete(
             [
                 Message(
                     role="user",

--- a/backend/core/providers/factory/abstract_provider_factory.py
+++ b/backend/core/providers/factory/abstract_provider_factory.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from core.domain.models import Provider
-from core.providers._base.abstract_provider import AbstractProvider, ProviderConfigInterface
+from core.providers._base.abstract_provider import AbstractProvider
 from core.providers._base.config import ProviderConfig
 
 
@@ -26,8 +26,9 @@ class AbstractProviderFactory(ABC):
         pass
 
     @abstractmethod
-    def provider_type[ProviderConfigVar: ProviderConfigInterface](
-        self,
-        config: ProviderConfigVar,
-    ) -> type[AbstractProvider[ProviderConfigVar, Any]]:
+    def provider_type(self, provider: Provider) -> type[AbstractProvider[Any, Any]]:
+        pass
+
+    @abstractmethod
+    def available_providers(self) -> Iterable[Provider]:
         pass

--- a/backend/core/runners/runner.py
+++ b/backend/core/runners/runner.py
@@ -232,6 +232,7 @@ class Runner:
 
     def _build_pipeline(self, builder: AgentCompletionBuilder):
         pipeline = ProviderPipeline(
+            agent_id=self._agent.id,
             version=self._version,
             custom_configs=self._custom_configs,
             factory=self._provider_factory,
@@ -257,11 +258,13 @@ class Runner:
         pipeline = self._build_pipeline(builder)
 
         # TODO: model_data
-        for provider, options, _ in pipeline.provider_iterator():
+        for provider, options, _ in pipeline.provider_iterator(raise_at_end=True):
             with pipeline.wrap_provider_call(provider):
                 return await self._build_output_from_messages(provider, options, builder.messages)
 
-        return pipeline.raise_on_end(self._agent.id)
+        # Will never be reached since raise_at_end is True
+        # Returning for type safety
+        return pipeline.raise_on_end()
 
     async def _prepare_messages(
         self,


### PR DESCRIPTION
Example error message

```
There are no configured provider supporting model 'gpt-4o-mini-2024-07-18'.
You can either configure them through the UI at `http://localhost:3000/providers` or by setting
the correct environment variables.
The possible providers and their associated environment variables are:
- openai (OPENAI_API_KEY)
- azure_openai (AZURE_OPENAI_CONFIG)
```

To reproduce:
- clear environment variables (either via `unset` or commenting out the .env)
- call the playground tool with a model