### PR TITLE
[AAI-14] Long string input variable spills over text box

### DIFF
--- a/web/src/components/VariablesViewer/ValueDisplay.tsx
+++ b/web/src/components/VariablesViewer/ValueDisplay.tsx
@@ -50,8 +50,13 @@ export function ValueDisplay({ value, textSize, showSeeMore }: ValueDisplayProps
   // Check height-based truncation - must be at top level
   useEffect(() => {
     if (contentRef.current && !isExpanded && showSeeMore && typeof value === "string") {
-      const height = contentRef.current.scrollHeight;
-      setShouldTruncateByHeight(height > MAX_HEIGHT_PX);
+      // Use requestAnimationFrame to ensure layout is complete after break-all wrapping
+      requestAnimationFrame(() => {
+        if (contentRef.current) {
+          const height = contentRef.current.scrollHeight;
+          setShouldTruncateByHeight(height > MAX_HEIGHT_PX);
+        }
+      });
     }
   }, [value, isExpanded, showSeeMore]);
 
@@ -95,7 +100,7 @@ export function ValueDisplay({ value, textSize, showSeeMore }: ValueDisplayProps
       <span
         ref={contentRef}
         className={cx(
-          "inline-block px-3 py-1.5 font-medium bg-white border border-gray-200 text-gray-800 rounded-[2px] relative",
+          "inline-block px-3 py-1.5 font-medium bg-white border border-gray-200 text-gray-800 rounded-[2px] relative break-all",
           textSizeClass
         )}
         style={textSizeStyle}
@@ -103,7 +108,7 @@ export function ValueDisplay({ value, textSize, showSeeMore }: ValueDisplayProps
         onMouseLeave={() => setIsHovered(false)}
       >
         <div
-          className={cx("py-1", shouldTruncateByHeight && !isExpanded ? "overflow-hidden" : "")}
+          className={cx("py-1 break-all", shouldTruncateByHeight && !isExpanded ? "overflow-hidden" : "")}
           style={shouldTruncateByHeight && !isExpanded ? { maxHeight: `${MAX_HEIGHT_PX - 30}px` } : {}}
         >
           {'"'}
@@ -153,7 +158,7 @@ export function ValueDisplay({ value, textSize, showSeeMore }: ValueDisplayProps
   return (
     <span
       className={cx(
-        "inline-block px-3 py-1.5 font-medium bg-white border border-gray-200 text-gray-800 rounded-[2px] relative",
+        "inline-block px-3 py-1.5 font-medium bg-white border border-gray-200 text-gray-800 rounded-[2px] relative break-all",
         textSizeClass
       )}
       style={textSizeStyle}

--- a/web/src/components/messages/MessageContentView.tsx
+++ b/web/src/components/messages/MessageContentView.tsx
@@ -73,7 +73,7 @@ export function MessageContentView(props: MessageContentViewProps) {
         return (
           <div key={index} className="text-[12.5px] text-gray-900">
             {item.text && (
-              <div className="whitespace-pre-wrap">
+              <div className="whitespace-pre-wrap break-words">
                 <MessageTextView text={item.text} sharedText={sharedText} compareMode={compareMode} />
               </div>
             )}

--- a/web/src/components/messages/MessageTextView.tsx
+++ b/web/src/components/messages/MessageTextView.tsx
@@ -43,7 +43,7 @@ export function MessageTextView(props: MessageTextViewProps) {
       <div>
         <div
           ref={contentRef}
-          className={shouldTruncateByHeight && !isExpanded ? "overflow-hidden" : ""}
+          className={`break-all ${shouldTruncateByHeight && !isExpanded ? "overflow-hidden" : ""}`}
           style={shouldTruncateByHeight && !isExpanded ? { maxHeight: `${MAX_HEIGHT_PX}px` } : {}}
         >
           {(() => {
@@ -77,7 +77,7 @@ export function MessageTextView(props: MessageTextViewProps) {
   const sharedWords = decodedSharedText!.trim().split(/\s+/);
 
   return (
-    <>
+    <div className="break-all">
       {words.map((word, i) => {
         const cleanWord = word.trim().toLowerCase();
         const isShared = sharedWords.some((sharedWord) => cleanWord && sharedWord.toLowerCase() === cleanWord);
@@ -98,6 +98,6 @@ export function MessageTextView(props: MessageTextViewProps) {
 
         return <React.Fragment key={i}>{word}</React.Fragment>;
       })}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Fixed same issues also in other places:
- input and output cells in completions
- same for experiment page
- completionModal, for input, output, messages and etc.

### Before:
<img width="1688" height="1233" alt="Before 1" src="https://github.com/user-attachments/assets/f86b8e4d-0966-41dc-8c40-b4f964963a27" />
<img width="1688" height="1233" alt="Before 2" src="https://github.com/user-attachments/assets/39711de0-fcd4-45a9-bb34-74a726c89822" />

### After:
<img width="1688" height="1233" alt="After 1" src="https://github.com/user-attachments/assets/b2f9ecea-f068-40c0-95bc-83c5cd75a9f4" />
<img width="1688" height="1233" alt="After 2" src="https://github.com/user-attachments/assets/75f91199-7d21-4128-894e-a2fe077fb595" />
