### PR TITLE
[39] [38] [37] [36] [35] [32] [31] Fixes

### DIFF
--- a/web/src/app/experiments/[id]/sections/Results/MatrixSection.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/MatrixSection.tsx
@@ -68,9 +68,12 @@ export function MatrixSection(props: Props) {
           priceAndLatency={
             priceAndLatency?.metrics
               ? {
-                  ...priceAndLatency.metrics,
+                  avgCost: priceAndLatency.metrics.avgCost,
+                  avgDuration: priceAndLatency.metrics.avgDuration,
                   allCosts: allAvgCosts,
                   allDurations: allAvgDurations,
+                  versionCosts: priceAndLatency.metrics.costs,
+                  versionDurations: priceAndLatency.metrics.durations,
                 }
               : undefined
           }

--- a/web/src/app/experiments/[id]/sections/Results/completion/CompletionCell.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/completion/CompletionCell.tsx
@@ -1,6 +1,7 @@
 import { Copy } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo, useState } from "react";
+import { HoverPopover } from "@/components/HoverPopover";
 import { PageError } from "@/components/PageError";
 import { PriceAndLatencyDisplay } from "@/components/PriceAndLatencyDisplay";
 import { useToast } from "@/components/ToastProvider";
@@ -125,13 +126,18 @@ export function CompletionCell(props: CompletionCellProps) {
           View Details
         </button>
         {isHovered && (
-          <button
-            onClick={handleCopyCompletion}
-            className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer h-8 w-8 rounded flex items-center justify-center"
-            title="Copy completion ID"
+          <HoverPopover
+            content={<div className="text-xs">Copy Completion ID</div>}
+            position="top"
+            popoverClassName="bg-gray-800 text-white rounded-[4px] px-2 py-1"
           >
-            <Copy size={12} />
-          </button>
+            <button
+              onClick={handleCopyCompletion}
+              className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer h-8 w-8 rounded flex items-center justify-center"
+            >
+              <Copy size={12} />
+            </button>
+          </HoverPopover>
         )}
       </div>
     </div>

--- a/web/src/app/experiments/[id]/sections/Results/completion/CompletionMetrics.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/completion/CompletionMetrics.tsx
@@ -1,5 +1,6 @@
 import { cx } from "class-variance-authority";
-import { getMetricBadgeColor } from "@/components/utils/utils";
+import { ArrowUp } from "lucide-react";
+import { getMetricBadgeWithRelative } from "@/components/utils/utils";
 
 type CompletionMetricsProps = {
   metrics?: { key: string; average: number }[];
@@ -17,15 +18,31 @@ export function CompletionMetrics(props: CompletionMetricsProps) {
     <div className="space-y-1">
       {metrics.map(({ key, average }) => {
         // Use row-based comparison coloring if available
-        const badgeColor =
+        const badgeInfo =
           allMetricsPerKeyForRow && allMetricsPerKeyForRow[key]
-            ? getMetricBadgeColor(average, allMetricsPerKeyForRow[key], true) // true = higher is better for most metrics
-            : "bg-transparent border border-gray-200 text-gray-700";
+            ? getMetricBadgeWithRelative(average, allMetricsPerKeyForRow[key], true) // true = higher is better for most metrics
+            : {
+                color: "bg-transparent border border-gray-200 text-gray-700",
+                relativeText: undefined,
+                isBest: false,
+                isWorst: false,
+              };
 
         return (
-          <div key={key} className={cx("flex justify-between items-center px-2 py-1 rounded text-xs", badgeColor)}>
+          <div key={key} className={cx("flex justify-between items-center px-2 py-1 rounded text-xs", badgeInfo.color)}>
             <span className="text-gray-600 capitalize">{key.replace(/_/g, " ")}</span>
-            <span className="font-medium">{average.toFixed(2)}</span>
+            <div className="flex items-center gap-1">
+              {badgeInfo.relativeText && badgeInfo.isBest && (
+                <span className="text-xs text-gray-500">{badgeInfo.relativeText}</span>
+              )}
+              {badgeInfo.relativeText && !badgeInfo.isBest && (
+                <span className="flex items-center text-xs font-medium text-red-500">
+                  {badgeInfo.relativeText}
+                  <ArrowUp size={12} />
+                </span>
+              )}
+              <span className="font-medium">{average.toFixed(2)}</span>
+            </div>
           </div>
         );
       })}

--- a/web/src/app/experiments/[id]/sections/Results/version/VersionHeader.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/version/VersionHeader.tsx
@@ -1,5 +1,7 @@
-import { useMemo } from "react";
+import { Copy } from "lucide-react";
+import { useMemo, useState } from "react";
 import { HoverPopover } from "@/components/HoverPopover";
+import { useToast } from "@/components/ToastProvider";
 import {
   findIndexOfVersionThatFirstUsedThosePrompt,
   findIndexOfVersionThatFirstUsedThosePromptAndSchema,
@@ -24,6 +26,8 @@ type VersionHeaderProps = {
     avgDuration: number;
     allCosts: number[];
     allDurations: number[];
+    versionCosts: number[];
+    versionDurations: number[];
   };
   versions?: Version[];
   sharedPartsOfPrompts?: Message[];
@@ -54,6 +58,20 @@ export function VersionHeader(props: VersionHeaderProps) {
     showAvgPrefix = true,
     agentId,
   } = props;
+
+  const [isHovered, setIsHovered] = useState(false);
+  const { showToast } = useToast();
+
+  const handleCopyVersion = async () => {
+    const versionPath = `anotherai/version/${version.id}`;
+    try {
+      await navigator.clipboard.writeText(versionPath);
+      showToast("Copied to clipboard");
+    } catch (err) {
+      console.error("Failed to copy: ", err);
+      showToast("Failed to copy");
+    }
+  };
 
   const optionalKeysToShowWithoutPromptAndOutputSchema = useMemo(() => {
     return optionalKeysToShow.filter((key) => key !== "prompt" && key !== "output_schema");
@@ -102,14 +120,25 @@ export function VersionHeader(props: VersionHeaderProps) {
   return (
     <div className="flex flex-col h-full text-xs">
       <div className="flex-1 space-y-2">
-        <div>
+        <div onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
           <HoverPopover
             content={<VersionDetailsView version={version} showPrompt={false} />}
             position="bottom"
             popoverClassName="rounded bg-white border border-gray-200 w-80"
           >
-            <div className="text-gray-800 font-semibold mb-2 text-sm cursor-pointer hover:text-gray-600">
-              Version {index + 1}
+            <div className="flex items-center gap-2 mb-2">
+              <div className="text-gray-800 font-semibold text-sm cursor-pointer hover:text-gray-600">
+                Version {index + 1}
+              </div>
+              {isHovered && (
+                <button
+                  onClick={handleCopyVersion}
+                  className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer h-5 w-5 rounded-[2px] flex items-center justify-center"
+                  title="Copy version ID"
+                >
+                  <Copy size={12} />
+                </button>
+              )}
             </div>
           </HoverPopover>
           <VersionHeaderModel

--- a/web/src/app/experiments/[id]/sections/Results/version/VersionHeader.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/version/VersionHeader.tsx
@@ -131,13 +131,18 @@ export function VersionHeader(props: VersionHeaderProps) {
                 Version {index + 1}
               </div>
               {isHovered && (
-                <button
-                  onClick={handleCopyVersion}
-                  className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer h-5 w-5 rounded-[2px] flex items-center justify-center"
-                  title="Copy version ID"
+                <HoverPopover
+                  content={<div className="text-xs">Copy Version ID</div>}
+                  position="top"
+                  popoverClassName="bg-gray-800 text-white rounded-[4px] px-2 py-1"
                 >
-                  <Copy size={12} />
-                </button>
+                  <button
+                    onClick={handleCopyVersion}
+                    className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer h-5 w-5 rounded-[2px] flex items-center justify-center"
+                  >
+                    <Copy size={12} />
+                  </button>
+                </HoverPopover>
               )}
             </div>
           </HoverPopover>

--- a/web/src/app/experiments/[id]/sections/Results/version/VersionHeaderMetrics.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/version/VersionHeaderMetrics.tsx
@@ -1,5 +1,6 @@
 import { cx } from "class-variance-authority";
-import { getMetricBadgeColor } from "@/components/utils/utils";
+import { ArrowUp } from "lucide-react";
+import { getMetricBadgeWithRelative } from "@/components/utils/utils";
 
 type VersionHeaderMetricsProps = {
   metrics?: { key: string; average: number }[];
@@ -18,17 +19,33 @@ export function VersionHeaderMetrics(props: VersionHeaderMetricsProps) {
     <div className="space-y-1 mt-1">
       {metrics.map(({ key, average }) => {
         // Use comparison coloring if all values are provided, otherwise use neutral styling
-        const badgeColor =
+        const badgeInfo =
           allMetricsPerKey && allMetricsPerKey[key]
-            ? getMetricBadgeColor(average, allMetricsPerKey[key], true) // true = higher is better for most metrics
-            : "bg-transparent border border-gray-200 text-gray-700";
+            ? getMetricBadgeWithRelative(average, allMetricsPerKey[key], true) // true = higher is better for most metrics
+            : {
+                color: "bg-transparent border border-gray-200 text-gray-700",
+                relativeText: undefined,
+                isBest: false,
+                isWorst: false,
+              };
 
         return (
-          <div key={key} className={cx("flex justify-between items-center px-2 py-1 rounded text-xs", badgeColor)}>
+          <div key={key} className={cx("flex justify-between items-center px-2 py-1 rounded text-xs", badgeInfo.color)}>
             <span className="text-gray-600 capitalize">
               {showAvgPrefix ? `Average ${key.replace(/_/g, " ")}` : key.replace(/_/g, " ")}
             </span>
-            <span className="font-medium">{average.toFixed(2)}</span>
+            <div className="flex items-center gap-1">
+              {badgeInfo.relativeText && badgeInfo.isBest && (
+                <span className="text-xs text-gray-500">{badgeInfo.relativeText}</span>
+              )}
+              {badgeInfo.relativeText && !badgeInfo.isBest && (
+                <span className="flex items-center text-xs font-medium text-red-500">
+                  {badgeInfo.relativeText}
+                  <ArrowUp size={12} />
+                </span>
+              )}
+              <span className="font-medium">{average.toFixed(2)}</span>
+            </div>
           </div>
         );
       })}

--- a/web/src/app/experiments/[id]/sections/Results/version/VersionHeaderModel.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/version/VersionHeaderModel.tsx
@@ -38,7 +38,6 @@ export function VersionHeaderModel(props: VersionHeaderModelProps) {
             </span>
           }
           position="rightOverlap"
-          delay={0}
           popoverClassName="bg-white border border-gray-200"
         >
           <div

--- a/web/src/app/experiments/[id]/sections/Results/version/VersionHeaderPriceAndLatency.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/version/VersionHeaderPriceAndLatency.tsx
@@ -6,6 +6,8 @@ type VersionHeaderPriceAndLatencyProps = {
     avgDuration: number;
     allCosts: number[];
     allDurations: number[];
+    versionCosts: number[];
+    versionDurations: number[];
   };
   showAvgPrefix?: boolean;
 };
@@ -23,6 +25,8 @@ export function VersionHeaderPriceAndLatency(props: VersionHeaderPriceAndLatency
       duration={priceAndLatency.avgDuration}
       allCosts={priceAndLatency.allCosts}
       allDurations={priceAndLatency.allDurations}
+      versionCosts={priceAndLatency.versionCosts}
+      versionDurations={priceAndLatency.versionDurations}
       showAvgPrefix={showAvgPrefix}
     />
   );

--- a/web/src/app/experiments/[id]/sections/Results/version/VersionOptionalKeysView.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/version/VersionOptionalKeysView.tsx
@@ -68,7 +68,6 @@ export function VersionOptionalKeysView(props: VersionOptionalKeysViewProps) {
                   </span>
                 }
                 position="rightOverlap"
-                delay={0}
                 popoverClassName="bg-white border border-gray-200"
                 className="w-full block"
               >

--- a/web/src/app/experiments/[id]/sections/matching/MatchingBaseValue.tsx
+++ b/web/src/app/experiments/[id]/sections/matching/MatchingBaseValue.tsx
@@ -49,7 +49,6 @@ export function MatchingBaseValue({ value, annotations, experimentId, completion
             </span>
           }
           position="topRightAligned"
-          delay={0}
           popoverClassName="bg-white border border-gray-200"
           className="w-full block"
         >

--- a/web/src/app/experiments/[id]/sections/matching/MatchingToolValue.tsx
+++ b/web/src/app/experiments/[id]/sections/matching/MatchingToolValue.tsx
@@ -53,7 +53,6 @@ export function MatchingToolValue({ tools, annotations, experimentId, completion
             </span>
           }
           position="topRightAligned"
-          delay={0}
           popoverClassName="bg-white border border-gray-200"
           className="w-full block"
         >

--- a/web/src/components/HoverPopover.tsx
+++ b/web/src/components/HoverPopover.tsx
@@ -26,7 +26,7 @@ export function HoverPopover({
   content,
   className = "inline-block",
   popoverClassName = "",
-  delay = 100,
+  delay = 50,
   position = "top",
 }: HoverPopoverProps) {
   const [isVisible, setIsVisible] = useState(false);

--- a/web/src/components/HoverPopover.tsx
+++ b/web/src/components/HoverPopover.tsx
@@ -8,15 +8,25 @@ type HoverPopoverProps = {
   className?: string;
   popoverClassName?: string;
   delay?: number;
-  position?: "top" | "bottom" | "left" | "right" | "topRight" | "topRightAligned" | "rightOverlap" | "bottomLeft";
+  position?:
+    | "top"
+    | "bottom"
+    | "left"
+    | "right"
+    | "topRight"
+    | "topRightAligned"
+    | "topLeftAligned"
+    | "topRightAlignedNew"
+    | "rightOverlap"
+    | "bottomLeft";
 };
 
 export function HoverPopover({
   children,
   content,
-  className = "",
+  className = "inline-block",
   popoverClassName = "",
-  delay = 0,
+  delay = 100,
   position = "top",
 }: HoverPopoverProps) {
   const [isVisible, setIsVisible] = useState(false);
@@ -35,8 +45,18 @@ export function HoverPopover({
 
     switch (position) {
       case "top":
-        top = rect.top - 32;
+        top = rect.top - 8; // Initial offset, will be adjusted after popover is rendered
         left = rect.left + rect.width / 2;
+        // Adjust after popover is rendered to position above the trigger
+        setTimeout(() => {
+          if (popoverRef.current) {
+            const popoverRect = popoverRef.current.getBoundingClientRect();
+            setPopoverPosition((prev) => ({
+              ...prev,
+              top: rect.top - popoverRect.height - 8,
+            }));
+          }
+        }, 0);
         break;
       case "bottom":
         top = rect.bottom + 4;
@@ -83,6 +103,35 @@ export function HoverPopover({
             const popoverRect = popoverRef.current.getBoundingClientRect();
             setPopoverPosition(() => ({
               top: rect.top - popoverRect.height + 8,
+              left: rect.right - popoverRect.width,
+            }));
+          }
+        }, 0);
+        break;
+      case "topLeftAligned":
+        top = rect.top - 8; // Initial offset, will be adjusted after popover is rendered
+        left = rect.left;
+        // Adjust after popover is rendered to position above the trigger
+        setTimeout(() => {
+          if (popoverRef.current) {
+            const popoverRect = popoverRef.current.getBoundingClientRect();
+            setPopoverPosition((prev) => ({
+              ...prev,
+              top: rect.top - popoverRect.height - 8,
+            }));
+          }
+        }, 0);
+        break;
+      case "topRightAlignedNew":
+        top = rect.top - 8; // Initial offset, will be adjusted after popover is rendered
+        left = rect.right;
+        // Adjust after popover is rendered to position above the trigger
+        setTimeout(() => {
+          if (popoverRef.current) {
+            const popoverRect = popoverRef.current.getBoundingClientRect();
+            setPopoverPosition((prev) => ({
+              ...prev,
+              top: rect.top - popoverRect.height - 8,
               left: rect.right - popoverRect.width,
             }));
           }
@@ -166,9 +215,11 @@ export function HoverPopover({
               ? "translateY(-50%)"
               : position === "topRight"
                 ? "translateX(-50%) translateY(-100%)"
-                : position === "bottomLeft"
+                : position === "bottomLeft" || position === "topLeftAligned"
                   ? "translateX(0)"
-                  : "translateX(-50%)",
+                  : position === "topRightAlignedNew"
+                    ? "translateX(0)"
+                    : "translateX(-50%)",
       }}
     >
       {content}
@@ -179,7 +230,7 @@ export function HoverPopover({
     <>
       <div
         ref={triggerRef}
-        className={cx("relative inline-block", className)}
+        className={cx("relative", className)}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >

--- a/web/src/components/PriceAndLatencyDisplay.tsx
+++ b/web/src/components/PriceAndLatencyDisplay.tsx
@@ -1,5 +1,7 @@
 import { cx } from "class-variance-authority";
-import { formatCurrency, formatDuration, getMetricBadgeColor } from "@/components/utils/utils";
+import { ArrowUp } from "lucide-react";
+import { formatCurrency, formatDuration, getMetricBadgeWithRelative } from "@/components/utils/utils";
+import { HoverPopover } from "./HoverPopover";
 
 type PriceAndLatencyDisplayProps = {
   cost: number;
@@ -7,31 +9,208 @@ type PriceAndLatencyDisplayProps = {
   // Optional props for comparison coloring (used in version headers)
   allCosts?: number[];
   allDurations?: number[];
+  // Optional props for version-specific percentiles (used for popover data)
+  versionCosts?: number[];
+  versionDurations?: number[];
   showAvgPrefix?: boolean;
 };
 
+type PercentilesPopoverProps = {
+  p50: number;
+  p90: number;
+  p99: number;
+  formatValue: (value: number) => string;
+};
+
+function PercentilesPopover({ p50, p90, p99, formatValue }: PercentilesPopoverProps) {
+  return (
+    <div className="space-y-1 py-1 w-[120px]">
+      <div className="flex justify-between items-center">
+        <span>p50:</span>
+        <span className="font-medium bg-white/10 px-2 py-1 rounded-[2px] border border-white/10">
+          {formatValue(p50)}
+        </span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span>p90:</span>
+        <span className="font-medium bg-white/10 px-2 py-1 rounded-[2px] border border-white/10">
+          {formatValue(p90)}
+        </span>
+      </div>
+      <div className="flex justify-between items-center">
+        <span>p99:</span>
+        <span className="font-medium bg-white/10 px-2 py-1 rounded-[2px] border border-white/10">
+          {formatValue(p99)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function calculatePercentile(sortedArray: number[], percentile: number): number {
+  const index = (percentile / 100) * (sortedArray.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  const weight = index % 1;
+
+  if (upper >= sortedArray.length) return sortedArray[sortedArray.length - 1];
+  return sortedArray[lower] * (1 - weight) + sortedArray[upper] * weight;
+}
+
 export function PriceAndLatencyDisplay(props: PriceAndLatencyDisplayProps) {
-  const { cost, duration, allCosts, allDurations, showAvgPrefix } = props;
+  const { cost, duration, allCosts, allDurations, versionCosts, versionDurations, showAvgPrefix } = props;
 
   // Use comparison coloring if arrays are provided, otherwise use neutral styling
-  const costBadgeColor = allCosts
-    ? getMetricBadgeColor(cost, allCosts, false)
-    : "bg-transparent border border-gray-200 text-gray-700";
+  const costBadgeInfo = allCosts
+    ? getMetricBadgeWithRelative(cost, allCosts, false)
+    : {
+        color: "bg-transparent border border-gray-200 text-gray-700",
+        relativeText: undefined,
+        isBest: false,
+        isWorst: false,
+      };
 
-  const durationBadgeColor = allDurations
-    ? getMetricBadgeColor(duration, allDurations, false)
-    : "bg-transparent border border-gray-200 text-gray-700";
+  const durationBadgeInfo = allDurations
+    ? getMetricBadgeWithRelative(duration, allDurations, false)
+    : {
+        color: "bg-transparent border border-gray-200 text-gray-700",
+        relativeText: undefined,
+        isBest: false,
+        isWorst: false,
+      };
+
+  // Calculate percentiles for duration using version-specific data if available
+  const durationPercentiles =
+    versionDurations && versionDurations.length > 0
+      ? (() => {
+          const sorted = [...versionDurations].sort((a, b) => a - b);
+          return {
+            p50: calculatePercentile(sorted, 50),
+            p90: calculatePercentile(sorted, 90),
+            p99: calculatePercentile(sorted, 99),
+          };
+        })()
+      : null;
+
+  // Calculate percentiles for cost using version-specific data if available
+  const costPercentiles =
+    versionCosts && versionCosts.length > 0
+      ? (() => {
+          const sorted = [...versionCosts].sort((a, b) => a - b);
+          return {
+            p50: calculatePercentile(sorted, 50),
+            p90: calculatePercentile(sorted, 90),
+            p99: calculatePercentile(sorted, 99),
+          };
+        })()
+      : null;
 
   return (
     <div className="space-y-1">
-      <div className={cx("flex justify-between items-center px-2 py-1 rounded text-xs", costBadgeColor)}>
-        <span className="text-gray-600">{showAvgPrefix ? "Average Cost" : "Cost"}</span>
-        <span className="font-medium">{formatCurrency(cost)}</span>
-      </div>
-      <div className={cx("flex justify-between items-center px-2 py-1 rounded text-xs", durationBadgeColor)}>
-        <span className="text-gray-600">{showAvgPrefix ? "Average Duration" : "Duration"}</span>
-        <span className="font-medium">{formatDuration(duration)}</span>
-      </div>
+      {costPercentiles && showAvgPrefix ? (
+        <HoverPopover
+          content={
+            <PercentilesPopover
+              p50={costPercentiles.p50}
+              p90={costPercentiles.p90}
+              p99={costPercentiles.p99}
+              formatValue={formatCurrency}
+            />
+          }
+          position="topRightAlignedNew"
+          popoverClassName="bg-gray-800 text-white rounded-[4px]"
+          className=""
+        >
+          <div
+            className={cx(
+              "flex justify-between items-center px-2 py-1 rounded text-xs cursor-pointer",
+              costBadgeInfo.color
+            )}
+          >
+            <span className="text-gray-600">{showAvgPrefix ? "Average Cost (per 1K)" : "Cost (per 1K)"}</span>
+            <div className="flex items-center gap-1">
+              {costBadgeInfo.relativeText && costBadgeInfo.isBest && (
+                <span className="text-xs text-gray-500">{costBadgeInfo.relativeText}</span>
+              )}
+              {costBadgeInfo.relativeText && !costBadgeInfo.isBest && (
+                <span className="flex items-center text-xs font-medium text-red-500">
+                  {costBadgeInfo.relativeText}
+                  <ArrowUp size={12} />
+                </span>
+              )}
+              <span className="font-medium">{formatCurrency(cost)}</span>
+            </div>
+          </div>
+        </HoverPopover>
+      ) : (
+        <div className={cx("flex justify-between items-center px-2 py-1 rounded text-xs", costBadgeInfo.color)}>
+          <span className="text-gray-600">{showAvgPrefix ? "Average Cost (per 1K)" : "Cost (per 1K)"}</span>
+          <div className="flex items-center gap-1">
+            {costBadgeInfo.relativeText && costBadgeInfo.isBest && (
+              <span className="text-xs text-gray-500">{costBadgeInfo.relativeText}</span>
+            )}
+            {costBadgeInfo.relativeText && !costBadgeInfo.isBest && (
+              <span className="flex items-center text-xs font-medium text-red-500">
+                {costBadgeInfo.relativeText}
+                <ArrowUp size={12} />
+              </span>
+            )}
+            <span className="font-medium">{formatCurrency(cost)}</span>
+          </div>
+        </div>
+      )}
+      {durationPercentiles && showAvgPrefix ? (
+        <HoverPopover
+          content={
+            <PercentilesPopover
+              p50={durationPercentiles.p50}
+              p90={durationPercentiles.p90}
+              p99={durationPercentiles.p99}
+              formatValue={formatDuration}
+            />
+          }
+          position="topRightAlignedNew"
+          popoverClassName="bg-gray-800 text-white rounded-[4px]"
+          className=""
+        >
+          <div
+            className={cx(
+              "flex justify-between items-center px-2 py-1 rounded text-xs cursor-pointer",
+              durationBadgeInfo.color
+            )}
+          >
+            <span className="text-gray-600">{showAvgPrefix ? "Average Duration" : "Duration"}</span>
+            <div className="flex items-center gap-1">
+              {durationBadgeInfo.relativeText && durationBadgeInfo.isBest && (
+                <span className="text-xs text-gray-500">{durationBadgeInfo.relativeText}</span>
+              )}
+              {durationBadgeInfo.relativeText && !durationBadgeInfo.isBest && (
+                <span className="flex items-center text-xs font-medium text-red-500">
+                  {durationBadgeInfo.relativeText}
+                  <ArrowUp size={12} />
+                </span>
+              )}
+              <span className="font-medium">{formatDuration(duration)}</span>
+            </div>
+          </div>
+        </HoverPopover>
+      ) : (
+        <div className={cx("flex justify-between items-center px-2 py-1 rounded text-xs", durationBadgeInfo.color)}>
+          <span className="text-gray-600">{showAvgPrefix ? "Average Duration" : "Duration"}</span>
+          <div className="flex items-center gap-1">
+            {durationBadgeInfo.relativeText && durationBadgeInfo.isBest && (
+              <span className="text-xs text-gray-500">{durationBadgeInfo.relativeText}</span>
+            )}
+            {durationBadgeInfo.relativeText && !durationBadgeInfo.isBest && (
+              <span className="flex items-center text-xs font-medium text-red-500">
+                {durationBadgeInfo.relativeText}
+                <ArrowUp size={12} />
+              </span>
+            )}
+            <span className="font-medium">{formatDuration(duration)}</span>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/SchemaViewer.tsx
+++ b/web/src/components/SchemaViewer.tsx
@@ -146,7 +146,7 @@ export function SchemaViewer(props: SchemaViewerProps) {
             {renderTypeBadge(resolvedNode.type)}
 
             {resolvedNode.enum && (
-              <span className="text-xs text-gray-500 font-normal">({resolvedNode.enum.length} values)</span>
+              <span className="text-xs text-gray-500 font-normal">({resolvedNode.enum.join(", ")})</span>
             )}
           </div>
 

--- a/web/src/components/VariablesViewer/HoverContainer.tsx
+++ b/web/src/components/VariablesViewer/HoverContainer.tsx
@@ -84,7 +84,6 @@ export const HoverContainer = (props: HoverContainerProps) => {
           </span>
         }
         position="topRight"
-        delay={0}
         popoverClassName="bg-white border border-gray-200"
       >
         {content}

--- a/web/src/components/completion-modal/CompletionDetailsView.tsx
+++ b/web/src/components/completion-modal/CompletionDetailsView.tsx
@@ -1,20 +1,56 @@
+import { Copy } from "lucide-react";
+import { useState } from "react";
 import { AnnotationsView } from "@/components/annotations/AnnotationsView";
 import { VersionDetailsView } from "@/components/version-details/VersionDetailsView";
 import { Annotation, Completion } from "@/types/models";
+import { useToast } from "../ToastProvider";
 import { AnnotationsPromptLabel } from "../annotations/AnnotationsPromptLabel";
 import { MetadataView } from "./MetadataView";
 
 type InfoRowProps = {
   title: string;
   value: string;
+  copyable?: boolean;
+  copyValue?: string; // Optional separate value for copying
 };
 
-function InfoRow({ title, value }: InfoRowProps) {
+function InfoRow({ title, value, copyable = false, copyValue }: InfoRowProps) {
+  const { showToast } = useToast();
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      // Use copyValue if provided, otherwise use display value
+      await navigator.clipboard.writeText(copyValue || value);
+      showToast("Copied to clipboard");
+    } catch (err) {
+      console.error("Failed to copy: ", err);
+      showToast("Failed to copy");
+    }
+  };
+
+  const showCopyButton = copyable && isHovered;
+
   return (
-    <div className="bg-white border border-gray-200 rounded-[2px] p-2">
+    <div
+      className="bg-white border border-gray-200 rounded-[2px] px-2"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
       <div className="flex justify-between items-center">
-        <span className="text-xs font-medium text-gray-700">{title}</span>
-        <span className="text-xs text-gray-900">{value}</span>
+        <span className="text-xs font-medium text-gray-700 py-2">{title}</span>
+        <div className="flex items-center gap-1">
+          <span className="text-xs text-gray-900 py-2">{value}</span>
+          {showCopyButton && (
+            <button
+              onClick={handleCopy}
+              className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer h-5 w-5 rounded-[2px] flex items-center justify-center ml-1"
+              title="Copy to clipboard"
+            >
+              <Copy size={12} />
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -54,6 +90,12 @@ export function CompletionDetailsView(props: Props) {
 
         <div className="space-y-2 px-4">
           <InfoRow title="Agent ID" value={completion.agent_id} />
+          <InfoRow
+            title="Version ID"
+            value={completion.version.id}
+            copyValue={`anotherai/version/${completion.version.id}`}
+            copyable={true}
+          />
 
           <VersionDetailsView version={completion.version} showPrompt={true} showOutputSchema={true} />
         </div>

--- a/web/src/components/completion-modal/CompletionModal.tsx
+++ b/web/src/components/completion-modal/CompletionModal.tsx
@@ -65,12 +65,18 @@ export function CompletionModal() {
             <h2 className="text-base font-bold">Completion Details</h2>
             <CompletionNavigationButtons completionId={completionId} />
           </div>
-          <button
-            onClick={copyCompletionId}
-            className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer px-2 py-1 rounded-[2px] w-8 h-8 flex items-center justify-center shadow-sm shadow-black/5"
-          >
-            <Copy size={16} />
-          </button>
+          <div className="flex items-center gap-1">
+            <span className="text-xs text-gray-700 font-mono bg-white px-3 h-8 rounded-[2px] border border-gray-200 items-center flex shadow-sm shadow-black/5">
+              anotherai/completion/{completionId}
+            </span>
+            <button
+              onClick={copyCompletionId}
+              className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer px-2 py-1 rounded-[2px] w-8 h-8 flex items-center justify-center shadow-sm shadow-black/5"
+              title="Copy to clipboard"
+            >
+              <Copy size={16} />
+            </button>
+          </div>
         </div>
 
         {!completion ? (

--- a/web/src/components/completion-modal/CompletionModal.tsx
+++ b/web/src/components/completion-modal/CompletionModal.tsx
@@ -65,18 +65,19 @@ export function CompletionModal() {
             <h2 className="text-base font-bold">Completion Details</h2>
             <CompletionNavigationButtons completionId={completionId} />
           </div>
-          <div className="flex items-center gap-1">
-            <span className="text-xs text-gray-700 font-mono bg-white px-3 h-8 rounded-[2px] border border-gray-200 items-center flex shadow-sm shadow-black/5">
-              anotherai/completion/{completionId}
-            </span>
+
             <button
               onClick={copyCompletionId}
-              className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer px-2 py-1 rounded-[2px] w-8 h-8 flex items-center justify-center shadow-sm shadow-black/5"
+              className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer px-2 py-1 rounded-[2px] h-8 flex items-center justify-center shadow-sm shadow-black/5"
               title="Copy to clipboard"
             >
-              <Copy size={16} />
+              <div className="flex items-center gap-2 px-0.5">
+              <Copy size={12} />
+            <span className="text-xs text-gray-700 font-mono items-center">
+              anotherai/completion/{completionId}
+            </span>
+              </div>
             </button>
-          </div>
         </div>
 
         {!completion ? (

--- a/web/src/components/completion-modal/CompletionModal.tsx
+++ b/web/src/components/completion-modal/CompletionModal.tsx
@@ -66,18 +66,16 @@ export function CompletionModal() {
             <CompletionNavigationButtons completionId={completionId} />
           </div>
 
-            <button
-              onClick={copyCompletionId}
-              className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer px-2 py-1 rounded-[2px] h-8 flex items-center justify-center shadow-sm shadow-black/5"
-              title="Copy to clipboard"
-            >
-              <div className="flex items-center gap-2 px-0.5">
+          <button
+            onClick={copyCompletionId}
+            className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer px-2 py-1 rounded-[2px] h-8 flex items-center justify-center shadow-sm shadow-black/5"
+            title="Copy to clipboard"
+          >
+            <div className="flex items-center gap-2 px-0.5">
               <Copy size={12} />
-            <span className="text-xs text-gray-700 font-mono items-center">
-              anotherai/completion/{completionId}
-            </span>
-              </div>
-            </button>
+              <span className="text-xs text-gray-700 font-mono items-center">anotherai/completion/{completionId}</span>
+            </div>
+          </button>
         </div>
 
         {!completion ? (

--- a/web/src/components/utils/utils.ts
+++ b/web/src/components/utils/utils.ts
@@ -27,6 +27,79 @@ export function getMetricBadgeColor(value: number, values: number[], isHigherBet
   return "bg-transparent border border-gray-200 text-gray-700";
 }
 
+export function getMetricBadgeWithRelative(value: number, values: number[], isHigherBetter: boolean = false) {
+  if (!values || values.length === 0) {
+    return {
+      color: "bg-transparent border border-gray-200 text-gray-700",
+      relativeText: undefined,
+      isBest: false,
+      isWorst: false,
+    };
+  }
+
+  const sortedValues = [...values].sort((a, b) => a - b);
+  const min = sortedValues[0];
+  const max = sortedValues[sortedValues.length - 1];
+
+  // If all values are the same, no relative comparison needed
+  if (min === max) {
+    return {
+      color: "bg-transparent border border-gray-200 text-gray-700",
+      relativeText: undefined,
+      isBest: false,
+      isWorst: false,
+    };
+  }
+
+  let color: string;
+  let isBest = false;
+  let isWorst = false;
+  let relativeText: string | undefined;
+
+  if (isHigherBetter) {
+    isBest = value === max;
+    isWorst = value === min;
+
+    if (isBest) {
+      color = "bg-green-200 border border-green-400 text-green-900";
+      relativeText = `${(max / min).toFixed(1)}x better`;
+    } else if (isWorst) {
+      color = "bg-red-200 border border-red-300 text-red-900";
+    } else {
+      color = "bg-transparent border border-gray-200 text-gray-700";
+    }
+
+    // For non-best values, show how much worse they are
+    if (!isBest && max > 0) {
+      relativeText = `${(max / value).toFixed(1)}x`;
+    }
+  } else {
+    isBest = value === min;
+    isWorst = value === max;
+
+    if (isBest) {
+      color = "bg-green-200 border border-green-400 text-green-900";
+      relativeText = `${(max / min).toFixed(1)}x better`;
+    } else if (isWorst) {
+      color = "bg-red-200 border border-red-300 text-red-900";
+    } else {
+      color = "bg-transparent border border-gray-200 text-gray-700";
+    }
+
+    // For non-best values, show how much worse they are
+    if (!isBest && min > 0) {
+      relativeText = `${(value / min).toFixed(1)}x`;
+    }
+  }
+
+  return {
+    color,
+    relativeText,
+    isBest,
+    isWorst,
+  };
+}
+
 export function formatCurrency(value: number, multiplier: number = 1000): string {
   // Convert using multiplier for better readability
   const adjustedValue = value * multiplier;
@@ -59,15 +132,22 @@ export function formatRelativeDate(value: unknown): string {
 export function calculateAverageMetrics(completions: ExperimentCompletion[]): {
   avgCost: number;
   avgDuration: number;
+  costs: number[];
+  durations: number[];
 } {
-  if (completions.length === 0) return { avgCost: 0, avgDuration: 0 };
+  if (completions.length === 0) return { avgCost: 0, avgDuration: 0, costs: [], durations: [] };
 
-  const totalCost = completions.reduce((sum, completion) => sum + (completion.cost_usd || 0), 0);
-  const totalDuration = completions.reduce((sum, completion) => sum + (completion.duration_seconds || 0), 0);
+  const costs = completions.map((completion) => completion.cost_usd || 0);
+  const durations = completions.map((completion) => completion.duration_seconds || 0);
+
+  const totalCost = costs.reduce((sum, cost) => sum + cost, 0);
+  const totalDuration = durations.reduce((sum, duration) => sum + duration, 0);
 
   return {
     avgCost: totalCost / completions.length,
     avgDuration: totalDuration / completions.length,
+    costs,
+    durations,
   };
 }
 
@@ -105,7 +185,7 @@ export function getPriceAndLatencyPerVersion(
   }>
 ): Array<{
   versionId: string;
-  metrics: { avgCost: number; avgDuration: number };
+  metrics: { avgCost: number; avgDuration: number; costs: number[]; durations: number[] };
 }> {
   return completionsPerVersion.map(({ versionId, completions }) => ({
     versionId,

--- a/web/src/utils/queries.ts
+++ b/web/src/utils/queries.ts
@@ -1,6 +1,6 @@
 export const defaultQueryParts = {
   select:
-    "SELECT id, agent_id, input_messages, input_variables, output_messages, output_error, version, duration_ds, cost_usd, updated_at",
+    "SELECT id, agent_id, input_messages, input_variables, output_messages, output_error, version, duration_ds, cost_usd, created_at",
   from: "FROM completions",
   orderBy: "ORDER BY created_at DESC",
   limit: "LIMIT 100",


### PR DESCRIPTION
### Fixes for:
- [x] Add anotherai/completion/id next to the copy button in Completion Modal
- [x] Show VersionId in CompletionModal, and make it copyable
- [x] created_at instead of updated_at in /completions table
- [x] Add Per 1K copy to the costs shown per 1000 + Add hover with p50, p90, p99
- [x] Display enum values in Output Schema UI
- [x] x relative difference between best and worst
- [x] Copy version_id and completion_id in Experiments Page

### Links to issues:
https://github.com/anotherai-dev/anotherai/issues/31
https://github.com/anotherai-dev/anotherai/issues/32
https://github.com/anotherai-dev/anotherai/issues/35
https://github.com/anotherai-dev/anotherai/issues/36
https://github.com/anotherai-dev/anotherai/issues/37
https://github.com/anotherai-dev/anotherai/issues/38
https://github.com/anotherai-dev/anotherai/issues/39

### Screenshots:
<img width="1504" height="1243" alt="1" src="https://github.com/user-attachments/assets/8d469348-2e24-45d8-abe7-e14e4c8c20f4" />
<img width="1504" height="1243" alt="2" src="https://github.com/user-attachments/assets/cadc73ca-1554-496d-bca9-cf343d214c1e" />
<img width="473" height="339" alt="3" src="https://github.com/user-attachments/assets/1069a809-5d9f-4da6-84a8-ba48fc6b0dac" />
<img width="422" height="222" alt="4" src="https://github.com/user-attachments/assets/65d95f92-7601-4f32-9b30-63c6dcbed2e6" />
<img width="895" height="404" alt="5" src="https://github.com/user-attachments/assets/d6a0aa7f-4c45-4071-b975-de8236f1a7dc" />
<img width="1206" height="205" alt="6" src="https://github.com/user-attachments/assets/e6d318a8-fa9b-4093-88b2-41577d86eb50" />
<img width="1213" height="145" alt="7" src="https://github.com/user-attachments/assets/931b6a06-0e59-4b23-bfd9-1032568e9c59" />
<img width="210" height="71" alt="8" src="https://github.com/user-attachments/assets/69ca10a5-b981-4f4b-930e-dd501fbbb815" />
<img width="811" height="129" alt="9" src="https://github.com/user-attachments/assets/c2c0f0f9-57d8-4459-895c-80fe49d9e32d" />

