### PR TITLE
Layout Fixes for Completion Page

### DIFF
--- a/web/src/app/completions/page.tsx
+++ b/web/src/app/completions/page.tsx
@@ -55,12 +55,13 @@ function CompletionsPageContent() {
   }, [value, router, searchParams]);
 
   return (
-    <div className="flex flex-col w-full h-full mx-auto px-4 py-8 gap-6 bg-gray-50">
+    <div className="flex flex-col w-full h-full mx-auto px-4 pt-4 pb-8 gap-4 bg-gray-50">
       <PageHeader
-        breadcrumbs={[{ label: "Completions" }]}
+        breadcrumbs={[]}
         title="Completions"
         description="Search through completions using SQL queries, view detailed completion lists, and open individual completion details for analysis"
         descriptionRightContent={<FilterCompletionsInstructions />}
+        className="pb-2"
       />
 
       <SearchSection


### PR DESCRIPTION
Found that the layout for the Completion Page was broken, this PR fix it:

### Before:
<img width="1620" height="1169" alt="Screenshot 2025-08-29 at 11 26 06 AM" src="https://github.com/user-attachments/assets/51256fd2-12b4-473c-b957-c579fcc0b624" />

### After:
<img width="1620" height="1169" alt="Screenshot 2025-08-29 at 11 26 43 AM" src="https://github.com/user-attachments/assets/457efb9a-13e1-4213-b685-252117e14c05" />
