### PR TITLE
[Fix] Docker Build Issue Fix

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -16,7 +16,7 @@ RUN apk update && \
 # Instals the dependencies via uv and copies the source code
 FROM base AS builder
 
-RUN apk add --no-cache build-base libffi-dev geos-dev rust cargo
+RUN apk add --no-cache build-base libffi-dev geos-dev
 
 ENV UV_COMPILE_BYTECODE=1  UV_LINK_MODE=copy
 

--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -16,7 +16,7 @@ RUN apk update && \
 # Instals the dependencies via uv and copies the source code
 FROM base AS builder
 
-RUN apk add --no-cache build-base libffi-dev geos-dev
+RUN apk add --no-cache build-base libffi-dev geos-dev rust cargo
 
 ENV UV_COMPILE_BYTECODE=1  UV_LINK_MODE=copy
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     build:
       context: .
       dockerfile: backend.Dockerfile
+    platform: linux/amd64
     ports:
       - 8000:8000
     env_file:


### PR DESCRIPTION
The issue is that the Docker image needs Rust compiler to build tiktoken from source, and the build of api was failing because of that.

@guillaq 
Could you check if that change is ok, only with it the docker starts the api for me.