### PR TITLE
New Loading and Empty stated for all Main Pages with Docs Links

### DIFF
--- a/web/src/app/agents/sections/table/AgentsTable.tsx
+++ b/web/src/app/agents/sections/table/AgentsTable.tsx
@@ -2,7 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
-import { LoadingIndicator } from "@/components/LoadingIndicator";
+import { EmptyState } from "@/components/EmptyState";
+import { LoadingState } from "@/components/LoadingState";
 import { PageError } from "@/components/PageError";
 import { SimpleTableComponent } from "@/components/SimpleTableComponent";
 import { formatRelativeDate, formatTotalCost } from "@/components/utils/utils";
@@ -102,18 +103,16 @@ export function AgentsTable(props: AgentsTableProps) {
   }
 
   if (isLoading) {
-    return (
-      <div className="bg-white border border-gray-200 rounded-lg p-8 text-center">
-        <LoadingIndicator />
-      </div>
-    );
+    return <LoadingState />;
   }
 
   if (!isLoading && displayData.length === 0) {
     return (
-      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
-        <p className="text-gray-500">No agents found.</p>
-      </div>
+      <EmptyState
+        title="No agents found."
+        subtitle="Create your first agent to get started"
+        documentationUrl="https://docs.anotherai.dev/agents"
+      />
     );
   }
 

--- a/web/src/app/agents/sections/table/AgentsTable.tsx
+++ b/web/src/app/agents/sections/table/AgentsTable.tsx
@@ -111,7 +111,7 @@ export function AgentsTable(props: AgentsTableProps) {
       <EmptyState
         title="No agents found."
         subtitle="Create your first agent to get started"
-        documentationUrl="https://docs.anotherai.dev/agents"
+        documentationUrl="https://docs.anotherai.dev/agents/building"
       />
     );
   }

--- a/web/src/app/completions/page.tsx
+++ b/web/src/app/completions/page.tsx
@@ -39,7 +39,7 @@ function CompletionsPageContent() {
         isLoading={isLoading}
       />
 
-      <CompletionsTable data={data ?? []} isLoading={isLoading} error={error} />
+      <CompletionsTable data={data ?? []} isLoading={isLoading} error={error} currentQuery={query} />
     </div>
   );
 }

--- a/web/src/app/completions/sections/table/CompletionsTable.tsx
+++ b/web/src/app/completions/sections/table/CompletionsTable.tsx
@@ -2,9 +2,12 @@
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
+import { EmptyState } from "@/components/EmptyState";
+import { LoadingState } from "@/components/LoadingState";
 import { PageError } from "@/components/PageError";
 import { SimpleTableComponent } from "@/components/SimpleTableComponent";
 import { transformCompletionsData } from "@/components/utils/utils";
+import { defaultQuery } from "@/utils/queries";
 import { CompletionTableCell } from "./cells/CompletionTableCell";
 
 interface CompletionsTableProps {
@@ -12,9 +15,10 @@ interface CompletionsTableProps {
   isLoading: boolean;
   error?: Error;
   maxHeight?: string;
+  currentQuery?: string;
 }
 
-export function CompletionsTable({ data, isLoading, error, maxHeight }: CompletionsTableProps) {
+export function CompletionsTable({ data, isLoading, error, maxHeight, currentQuery }: CompletionsTableProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -56,12 +60,24 @@ export function CompletionsTable({ data, isLoading, error, maxHeight }: Completi
     return <PageError error={error.message} />;
   }
 
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
   if (!isLoading && data.length === 0) {
-    return (
-      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
-        <p className="text-gray-500">No completions found. Try adjusting your query.</p>
-      </div>
-    );
+    const isDefaultQuery = currentQuery === defaultQuery;
+
+    if (isDefaultQuery) {
+      return (
+        <EmptyState
+          title="No completions created yet."
+          subtitle="Start by creating your first completion using the AnotherAI API and MCP."
+          documentationUrl="https://docs.anotherai.dev"
+        />
+      );
+    }
+
+    return <EmptyState title="No completions found." subtitle="Try adjusting your query." />;
   }
 
   if (data.length === 0) {

--- a/web/src/app/deployments/sections/table/DeploymentsTable.tsx
+++ b/web/src/app/deployments/sections/table/DeploymentsTable.tsx
@@ -3,7 +3,8 @@
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
 import { ActivityIndicator } from "@/components/ActivityIndicator";
-import { LoadingIndicator } from "@/components/LoadingIndicator";
+import { EmptyState } from "@/components/EmptyState";
+import { LoadingState } from "@/components/LoadingState";
 import { PageError } from "@/components/PageError";
 import { SimpleTableComponent } from "@/components/SimpleTableComponent";
 import { formatDate, formatTotalCost } from "@/components/utils/utils";
@@ -90,7 +91,7 @@ export function DeploymentsTable(props: DeploymentsTableProps) {
 
   // Loading state
   if (isLoading) {
-    return <LoadingIndicator />;
+    return <LoadingState />;
   }
 
   // Error state
@@ -101,10 +102,11 @@ export function DeploymentsTable(props: DeploymentsTableProps) {
   // Empty state
   if (deployments.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-12 text-gray-500">
-        <div className="text-lg font-medium mb-2">No deployments found</div>
-        <div className="text-sm">Create your first deployment to get started</div>
-      </div>
+      <EmptyState
+        title="No deployments found"
+        subtitle="Create your first deployment to get started"
+        documentationUrl="https://docs.anotherai.dev/deployments"
+      />
     );
   }
 

--- a/web/src/app/experiments/[id]/page.tsx
+++ b/web/src/app/experiments/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from "next/navigation";
 import ErrorState from "@/components/ErrorState";
-import LoadingState from "@/components/LoadingState";
+import { LoadingState } from "@/components/LoadingState";
 import { PageHeader } from "@/components/PageHeader";
 import { ImproveAgentAnnotationsInstructions } from "@/components/experiment/ImproveAgentAnnotationsInstructions";
 import { useOrFetchAnnotations } from "@/store/annotations";

--- a/web/src/app/experiments/page.tsx
+++ b/web/src/app/experiments/page.tsx
@@ -12,7 +12,7 @@ export default function ExperimentsPage() {
       <div className="flex-1 mx-auto px-4 py-8 gap-6 bg-gray-50 w-full min-h-full">
         <HeaderSection title="Experiments" description="View and analyze your AI model experiments and results" />
 
-        <div className="mt-6">
+        <div className="mt-6 flex-1 flex flex-col">
           <ExperimentsTable
             experiments={experiments}
             total={total}

--- a/web/src/app/experiments/sections/table/ExperimentsTable.tsx
+++ b/web/src/app/experiments/sections/table/ExperimentsTable.tsx
@@ -2,7 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { useMemo } from "react";
-import { LoadingIndicator } from "@/components/LoadingIndicator";
+import { EmptyState } from "@/components/EmptyState";
+import { LoadingState } from "@/components/LoadingState";
 import { PageError } from "@/components/PageError";
 import { Pagination } from "@/components/Pagination";
 import { SimpleTableComponent } from "@/components/SimpleTableComponent";
@@ -77,19 +78,16 @@ export function ExperimentsTable(props: ExperimentsTableProps) {
   }
 
   if (isLoading) {
-    return (
-      <div className="bg-white border border-gray-200 rounded-lg p-8 text-center">
-        <LoadingIndicator />
-      </div>
-    );
+    return <LoadingState />;
   }
 
   if (!isLoading && displayData.length === 0) {
     return (
-      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
-        <p className="text-gray-500">No experiments found.</p>
-        <p className="text-gray-400 text-sm mt-2">Create your first experiment to get started</p>
-      </div>
+      <EmptyState
+        title="No experiments found."
+        subtitle="Create your first experiment to get started"
+        documentationUrl="https://docs.anotherai.dev/experiments"
+      />
     );
   }
 

--- a/web/src/app/experiments/sections/table/ExperimentsTable.tsx
+++ b/web/src/app/experiments/sections/table/ExperimentsTable.tsx
@@ -86,7 +86,7 @@ export function ExperimentsTable(props: ExperimentsTableProps) {
       <EmptyState
         title="No experiments found."
         subtitle="Create your first experiment to get started"
-        documentationUrl="https://docs.anotherai.dev/experiments"
+        documentationUrl="https://docs.anotherai.dev/agents/improving#experiments"
       />
     );
   }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   <div className="mb-6">
                     <p className="text-sm text-gray-600">Please sign in to continue</p>
                   </div>
-                  <div className="space-y-2">
+                  <div className="space-y-3">
                     <SignInButton>
                       <button className="w-full bg-blue-600 text-white hover:bg-blue-700 cursor-pointer px-6 py-2 rounded-[2px] font-medium transition-colors duration-200">
                         Sign In
@@ -58,10 +58,21 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                     <div>
                       <span className="text-gray-600 text-sm">{`Don't have an account? `}</span>
                       <SignUpButton>
-                        <button className="text-gray-900 hover:text-gray-700 text-sm font-medium transition-colors duration-200 cursor-pointer">
+                        <button className="text-blue-600 hover:text-blue-700 text-sm font-medium transition-colors duration-200 cursor-pointer">
                           Sign Up
                         </button>
                       </SignUpButton>
+                    </div>
+                    <div className="pt-2 border-t border-gray-200">
+                      <span className="text-gray-600 text-sm">Want to learn more? </span>
+                      <a
+                        href="https://docs.anotherai.dev"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:text-blue-700 text-sm font-medium transition-colors duration-200 cursor-pointer"
+                      >
+                        Read the documentation
+                      </a>
                     </div>
                   </div>
                 </div>

--- a/web/src/app/views/[id]/page.tsx
+++ b/web/src/app/views/[id]/page.tsx
@@ -6,7 +6,7 @@ import { SearchSection } from "@/app/completions/sections/SearchSection";
 import { CompletionsTable } from "@/app/completions/sections/table/CompletionsTable";
 import ErrorState from "@/components/ErrorState";
 import { HoverPopover } from "@/components/HoverPopover";
-import LoadingState from "@/components/LoadingState";
+import { LoadingState } from "@/components/LoadingState";
 import { PageHeader } from "@/components/PageHeader";
 import { CompletionsGraph } from "@/components/universal-charts/CompletionsGraph";
 import { useCompletionsListSync } from "@/hooks/useCompletionsListSync";

--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+
+interface EmptyStateProps {
+  title: string;
+  subtitle?: string;
+  documentationUrl?: string;
+  buttonText?: string;
+}
+
+export function EmptyState({ title, subtitle, documentationUrl, buttonText = "View Documentation" }: EmptyStateProps) {
+  return (
+    <div className="h-full flex flex-col items-center text-center" style={{ paddingTop: "25%" }}>
+      <p className="text-gray-500 mb-1">{title}</p>
+      {subtitle && <p className="text-gray-400 text-sm mb-4">{subtitle}</p>}
+      {documentationUrl && (
+        <button
+          onClick={() => window.open(documentationUrl, "_blank", "noopener,noreferrer")}
+          className="bg-white border border-gray-200 text-gray-900 hover:bg-gray-100 cursor-pointer px-2.5 py-1.5 rounded-[2px] text-[13px] shadow-sm shadow-black/5 inline-flex items-center gap-2"
+        >
+          <ExternalLink className="w-4 h-4" />
+          {buttonText}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/LoadingState.tsx
+++ b/web/src/components/LoadingState.tsx
@@ -1,19 +1,9 @@
-export default function LoadingState() {
+import { LoadingIndicator } from "@/components/LoadingIndicator";
+
+export function LoadingState() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="animate-pulse">
-        <div className="h-8 bg-gray-200 rounded w-1/2 mb-6"></div>
-        <div className="space-y-6">
-          <div className="bg-gray-100 rounded-lg p-6">
-            <div className="h-6 bg-gray-200 rounded w-1/4 mb-3"></div>
-            <div className="h-4 bg-gray-200 rounded w-3/4"></div>
-          </div>
-          <div className="bg-gray-100 rounded-lg p-6">
-            <div className="h-6 bg-gray-200 rounded w-1/4 mb-3"></div>
-            <div className="h-32 bg-gray-200 rounded"></div>
-          </div>
-        </div>
-      </div>
+    <div className="h-full flex flex-col items-center text-center" style={{ paddingTop: "25%" }}>
+      <LoadingIndicator />
     </div>
   );
 }

--- a/web/src/components/sidebar/NavigationSidebar.tsx
+++ b/web/src/components/sidebar/NavigationSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronLeft, Cloud, Search, Settings } from "lucide-react";
+import { ChevronLeft, Cloud, FileText, Search, Settings } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -138,6 +138,15 @@ export default function NavigationSidebar({ onOpenCommandPalette }: NavigationSi
           >
             <Settings className="w-4 h-4" />
             MCP Set Up
+          </a>
+          <a
+            href="https://docs.anotherai.dev"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-3 px-3 py-2 rounded-[4px] text-sm transition-colors mb-1 text-gray-700 hover:bg-gray-100"
+          >
+            <FileText className="w-4 h-4" />
+            Documentation
           </a>
         </div>
 


### PR DESCRIPTION
Requests from Slack:
`[@jacek.zimonski](https://workflowaihq.slack.com/team/U05SZFUQU75) add [docs.anotherai.dev](http://docs.anotherai.dev/) as a new "Documentation" link + add documentation link to logged-out`
`TODO: adding a link to the documentation here would be great.`

+ better loading states

<img width="1613" height="1308" alt="Screenshot 2025-09-03 at 2 17 12 PM" src="https://github.com/user-attachments/assets/d62866bb-df34-47a5-8412-57187432005d" />
<img width="1613" height="1308" alt="Screenshot 2025-09-03 at 2 17 14 PM" src="https://github.com/user-attachments/assets/c26a5bcb-fd28-4f55-9bc2-f341a0e67aba" />
<img width="1613" height="1308" alt="Screenshot 2025-09-03 at 2 17 16 PM" src="https://github.com/user-attachments/assets/8ff90d5a-e419-4f4a-a9f0-8894b2e97a06" />
<img width="1613" height="1308" alt="Screenshot 2025-09-03 at 2 17 18 PM" src="https://github.com/user-attachments/assets/cb621b75-ed3d-4075-b6e4-f46ed89c6c76" />
<img width="1613" height="1308" alt="Screenshot 2025-09-03 at 2 17 51 PM" src="https://github.com/user-attachments/assets/22032315-2068-4e9a-bf56-fa6c15b8eaea" />
