### PR TITLE
Improve clarity of AI engineer messaging in docs

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -11,9 +11,9 @@ import { Code2, BookOpen, Wand2, Eye, Network, FileCode, Shield } from 'lucide-r
 
 **AnotherAI turns your AI coding assistant into your AI engineer.**
 
-Claude Code, Cursor, and Windsurf operate your AI agents through MCP. Compatible with any programming language and SDK (OpenAI, Vercel AI, PydanticAI, Instructor), access every LLM model from: OpenAI, Anthropic, Google, Meta, DeepSeek, Mistral, and more. Fully [open-source](https://github.com/anotherai-dev/anotherai).
+Let Claude Code, Cursor, and Windsurf operate your AI agents through MCP. Compatible with any programming language and SDK (OpenAI, Vercel AI, PydanticAI, Instructor), access every LLM model from: OpenAI, Anthropic, Google, Meta, DeepSeek, Mistral, and more. Fully [open-source](https://github.com/anotherai-dev/anotherai).
 
-**What your AI engineer can do:**
+**With AnotherAI, your coding assistant becomes an AI engineer that can:**
 - **Debug production issues:** "Why is the email parser failing?" → Queries logs, identifies patterns, deploys fix
 - **Run experiments:** "Compare GPT-4o vs Claude Sonnet 4 on accuracy and cost" → A/B tests models and prompts with production data
 - **Deploy without code changes:** "Make the support bot more concise" → Updates prompts instantly, no PR needed


### PR DESCRIPTION
## Summary
- Improved the flow and clarity of the documentation landing page messaging
- Made it clearer that "AI engineer" refers to the enhanced coding assistant

## Changes
- Added "Let" before listing AI coding assistants for better readability
- Changed "What your AI engineer can do" to "With AnotherAI, your coding assistant becomes an AI engineer that can:"
- Commented out placeholder video section to clean up the page

These changes make it more explicit that Claude Code, Cursor, or Windsurf become AI engineers through AnotherAI's capabilities.

🤖 Generated with [Claude Code](https://claude.ai/code)