### PR TITLE
[AAI-70] add the  examples description on the output schema on the experimentation page

### DIFF
--- a/web/src/app/experiments/[id]/sections/Results/version/VersionSchemaSection.tsx
+++ b/web/src/app/experiments/[id]/sections/Results/version/VersionSchemaSection.tsx
@@ -31,6 +31,8 @@ export function VersionSchemaSection(props: VersionSchemaSectionProps) {
         annotations={annotations}
         annotationPrefix={prefix}
         onKeypathSelect={handleKeypathSelect}
+        showDescriptions={true}
+        showExamples={true}
       />
       <AnnotationsView
         annotations={annotations}


### PR DESCRIPTION
### Closes:
https://linear.app/anotherai-dev/issue/AAI-70/add-the-examples-description-on-the-output-schema-on-the

### Screenshot:
<img width="1370" height="464" alt="Screenshot 2025-09-10 at 11 48 08 AM" src="https://github.com/user-attachments/assets/7f2c910d-b9cc-48c8-8576-1a232668b900" />
