### PR TITLE
Groq schema serialization in message

### DIFF
--- a/backend/core/runners/runner.py
+++ b/backend/core/runners/runner.py
@@ -218,7 +218,7 @@ class Runner:
         # Overriding the structured generation flag if the model does not support it
         # Post provider override
         if not model_data_copy.supports_structured_output:
-            is_structured_generation_enabled = False
+            provider_options.structured_generation = False
 
         return provider, provider_options, model_data_copy
 
@@ -235,7 +235,7 @@ class Runner:
             version=self._version,
             custom_configs=self._custom_configs,
             factory=self._provider_factory,
-            builder=self._build_provider_data,  # TODO: not sure what this is
+            builder=self._build_provider_data,
             typology=IOTypology(input=builder.agent_input.typology, output=Typology()),
             use_fallback=self._use_fallback,
         )

--- a/backend/tests/components/_common.py
+++ b/backend/tests/components/_common.py
@@ -21,12 +21,18 @@ def anthropic_endpoint():
     return "https://api.anthropic.com/v1/messages"
 
 
+def groq_endpoint():
+    return "https://api.groq.com/openai/v1/chat/completions"
+
+
 def provider_matchers(provider: str, model: str) -> dict[str, Any]:
     match provider:
         case Provider.OPEN_AI:
             return {"url": openai_endpoint()}
         case Provider.ANTHROPIC:
             return {"url": anthropic_endpoint()}
+        case Provider.GROQ:
+            return {"url": groq_endpoint()}
         case _:
             raise ValueError(f"Unknown provider: {provider}")
 

--- a/backend/tests/components/run/_base.py
+++ b/backend/tests/components/run/_base.py
@@ -1,4 +1,10 @@
+# ruff: noqa: S101
+
+import json
 from abc import ABC, abstractmethod
+from typing import Any
+
+import httpx
 
 from core.domain.models.models import Model
 from core.domain.models.providers import Provider
@@ -16,6 +22,10 @@ class ProviderTestCase(ABC):
     def model(self) -> Model:
         pass
 
+    @abstractmethod
+    def validate_structured_output_request(self, payload: dict[str, Any], request: httpx.Request):
+        pass
+
 
 class OpenAITestCase(ProviderTestCase):
     def provider(self) -> Provider:
@@ -23,3 +33,46 @@ class OpenAITestCase(ProviderTestCase):
 
     def model(self) -> Model:
         return Model.GPT_41_MINI_2025_04_14
+
+    def validate_structured_output_request(self, payload: dict[str, Any], request: httpx.Request):
+        response_format = payload.get("response_format")
+        assert response_format
+        assert response_format.get("type") == "json_schema"
+        json_schema = response_format.get("json_schema")
+        assert json_schema
+        assert "name" in json_schema
+        assert json_schema["schema"] == {
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name", "age"],
+            "type": "object",
+            "additionalProperties": False,
+        }
+
+
+class GroqTestCase(ProviderTestCase):
+    def provider(self) -> Provider:
+        return Provider.GROQ
+
+    def model(self) -> Model:
+        return Model.LLAMA_4_MAVERICK_FAST
+
+    def validate_structured_output_request(self, payload: dict[str, Any], request: httpx.Request):
+        # Groq does not support structured output very well
+        # Instead the payload should be inlined in the message
+        response_format = payload.get("response_format")
+        assert response_format == {"type": "text"}
+
+        messages = payload.get("messages")
+        assert messages
+        assert len(messages) == 2
+        message = messages[0]
+        assert message.get("role") == "system"
+        content = message.get("content")
+        assert "Return a single JSON object enforcing the following schema" in content
+        # Extract the JSON schema
+        splits = content.split("```")
+        assert len(splits) == 3
+        json_schema_str = splits[1]
+        assert json_schema_str.startswith("json")
+        json_schema = json.loads(json_schema_str.removeprefix("json"))
+        assert json_schema

--- a/backend/tests/fixtures/groq/structured_output.json
+++ b/backend/tests/fixtures/groq/structured_output.json
@@ -1,0 +1,63 @@
+{
+  "id": "chatcmpl-91gL0PXUwQajck2pIp284pR9o7yVo",
+  "object": "chat.completion",
+  "created": 1710188102,
+  "model": "gpt-4",
+  "prompt_filter_results": [
+    {
+      "prompt_index": 0,
+      "content_filter_results": {
+        "hate": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "self_harm": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "sexual": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "violence": {
+          "filtered": false,
+          "severity": "safe"
+        }
+      }
+    }
+  ],
+  "choices": [
+    {
+      "finish_reason": "stop",
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "{\"name\": \"John Doe\", \"age\": 30}"
+      },
+      "content_filter_results": {
+        "hate": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "self_harm": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "sexual": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "violence": {
+          "filtered": false,
+          "severity": "safe"
+        }
+      }
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 35,
+    "completion_tokens": 109,
+    "total_tokens": 144
+  },
+  "system_fingerprint": "fp_8abb16fa4e"
+}


### PR DESCRIPTION
Fix a nasty bug in which the json schema was not inlined for groq models.
The split between model data and the provider class is not great. We should look at sanitizing when we have a chance.