### PR TITLE
[AAI-59] Add info button next to add annotations button

### DIFF
--- a/web/src/components/annotations/AnnotationsView.tsx
+++ b/web/src/components/annotations/AnnotationsView.tsx
@@ -1,7 +1,10 @@
 import { Plus } from "lucide-react";
+import { Info } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { Annotation } from "@/types/models";
 import { useAnnotationActions } from "../../store/annotations";
+import { HoverPopover } from "../HoverPopover";
+import { ImproveAgentAnnotationsInstructionsContent } from "../experiment/ImproveAgentAnnotationsInstructionsContent";
 import { AnnotationFilters, filterAnnotations } from "../utils/utils";
 import { AddAnnotationForm } from "./AddAnnotationForm";
 import { AnnotationView } from "./AnnotationView";
@@ -91,14 +94,31 @@ export function AnnotationsView({
 
       {showAddButton && !isAdding && !alwaysShowAddForm && (
         <div className="mb-2 flex flex-row justify-between items-center w-full">
-          <button
-            onClick={handleAddAnnotation}
-            className="text-xs px-2 py-1 bg-transparent border border-indigo-200 text-indigo-700 rounded-sm transition-colors flex items-center gap-1 cursor-pointer hover:bg-indigo-50 flex-shrink-0"
-            title="Add annotation"
-          >
-            <Plus size={12} />
-            Add Annotation
-          </button>
+          <div className="flex flex-row">
+            <button
+              onClick={handleAddAnnotation}
+              className="text-xs px-2 py-1 bg-transparent border border-indigo-200 text-indigo-700 rounded-l-sm transition-colors flex items-center gap-1 cursor-pointer hover:bg-indigo-50 flex-shrink-0"
+              title="Add annotation"
+            >
+              <Plus size={12} />
+              Add Annotation
+            </button>
+            {agentId && (
+              <HoverPopover
+                content={<ImproveAgentAnnotationsInstructionsContent agentId={agentId} />}
+                position="bottom"
+                popoverClassName="bg-gray-900 text-white rounded-[4px]"
+                className=""
+              >
+                <button
+                  className=" flex h-full text-xs px-1.5 py-1 bg-transparent border-l-0 border border-indigo-200 text-indigo-700 rounded-r-sm transition-colors items-center gap-1 cursor-pointer hover:bg-indigo-50 flex-shrink-0"
+                  title="Annotation prompt"
+                >
+                  <Info size={12} />
+                </button>
+              </HoverPopover>
+            )}
+          </div>
 
           {agentId && <AnnotationsPromptLabel annotations={filteredAnnotations} agentId={agentId} />}
         </div>

--- a/web/src/components/experiment/ImproveAgentAnnotationsInstructions.tsx
+++ b/web/src/components/experiment/ImproveAgentAnnotationsInstructions.tsx
@@ -3,84 +3,16 @@
 import { Info } from "lucide-react";
 import React from "react";
 import { HoverPopover } from "@/components/HoverPopover";
-import { useToast } from "@/components/ToastProvider";
+import { ImproveAgentAnnotationsInstructionsContent } from "./ImproveAgentAnnotationsInstructionsContent";
 
 interface ImproveAgentAnnotationsInstructionsProps {
   agentId: string;
 }
 
 export function ImproveAgentAnnotationsInstructions({ agentId }: ImproveAgentAnnotationsInstructionsProps) {
-  const { showToast } = useToast();
-
-  const promptText = `Adjust anotherai/agent/${agentId} based on the annotations that have been added. `;
-
-  const handleCopyPrompt = async () => {
-    try {
-      await navigator.clipboard.writeText(promptText);
-      showToast("Annotation prompt copied to clipboard");
-    } catch (err) {
-      console.error("Failed to copy prompt: ", err);
-      showToast("Failed to copy prompt");
-    }
-  };
-
-  const handleLearnMore = () => {
-    window.open("https://docs.anotherai.dev/agents/improving#annotations", "_blank");
-  };
-
-  const instructionsContent = (
-    <div className="w-[365px] py-1.5 px-1">
-      <div className="text-xs font-medium text-white">
-        <div className="whitespace-pre-wrap break-words">
-          Annotations allow you to add comments to your completions and experiments, that can then be used by your AI
-          coding agent to improve the agent you&apos;re building.
-        </div>
-
-        <div className="mt-3">
-          <div className="font-medium mb-1">How to use:</div>
-          <div className="ml-2 space-y-1 text-xs font-normal">
-            <div className="flex">
-              <span className="mr-1 flex-shrink-0">1.</span>
-              <span className="flex-1 w-full whitespace-pre-wrap break-words">
-                Leave annotations on each completion about what&apos;s working and what isn&apos;t
-              </span>
-            </div>
-            <div className="flex">
-              <span className="mr-1 flex-shrink-0">2.</span>
-              <span className="flex-1 w-full whitespace-pre-wrap break-words">
-                Copy and paste the prompt below into the client&apos;s chat, and fill in the details you&apos;d like to
-                update:
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <div className="mt-3 italic font-bold w-full whitespace-pre-wrap">
-          Adjust anotherai/agent/{agentId} based on the annotations that have been added....[describe the specific
-          improvements you want here]
-        </div>
-      </div>
-
-      <div className="flex gap-2 mt-4 w-full items-center justify-end">
-        <button
-          onClick={handleLearnMore}
-          className="flex items-center gap-1 bg-gray-700 text-white font-bold px-3 py-1.5 rounded-[2px] text-xs hover:bg-gray-800 transition-colors cursor-pointer"
-        >
-          Learn More About Annotations
-        </button>
-        <button
-          onClick={handleCopyPrompt}
-          className="flex items-center gap-1 bg-gray-700 text-white font-bold px-3 py-1.5 rounded-[2px] text-xs hover:bg-gray-800 transition-colors cursor-pointer"
-        >
-          Copy Annotation Prompt
-        </button>
-      </div>
-    </div>
-  );
-
   return (
     <HoverPopover
-      content={instructionsContent}
+      content={<ImproveAgentAnnotationsInstructionsContent agentId={agentId} />}
       position="bottom"
       popoverClassName="bg-gray-900 text-white rounded-[4px]"
     >

--- a/web/src/components/experiment/ImproveAgentAnnotationsInstructionsContent.tsx
+++ b/web/src/components/experiment/ImproveAgentAnnotationsInstructionsContent.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import React from "react";
+import { useToast } from "@/components/ToastProvider";
+
+interface ImproveAgentAnnotationsInstructionsContentProps {
+  agentId: string;
+}
+
+export function ImproveAgentAnnotationsInstructionsContent({
+  agentId,
+}: ImproveAgentAnnotationsInstructionsContentProps) {
+  const { showToast } = useToast();
+
+  const promptText = `Adjust anotherai/agent/${agentId} based on the annotations that have been added. `;
+  const copyButtonText = "Copy Annotation Prompt";
+  const learnMoreUrl = "https://docs.anotherai.dev/agents/improving#annotations";
+  const learnMoreButtonText = "Learn More About Annotations";
+  const copySuccessMessage = "Annotation prompt copied to clipboard";
+
+  const handleCopyPrompt = async () => {
+    try {
+      await navigator.clipboard.writeText(promptText);
+      showToast(copySuccessMessage);
+    } catch (err) {
+      console.error("Failed to copy prompt: ", err);
+      showToast("Failed to copy prompt");
+    }
+  };
+
+  const handleLearnMore = () => {
+    window.open(learnMoreUrl, "_blank");
+  };
+
+  return (
+    <div className="w-[365px] py-1.5 px-1">
+      <div className="text-xs font-medium text-white">
+        <div className="whitespace-pre-wrap break-words">
+          Annotations allow you to add comments to your completions and experiments, that can then be used by your AI
+          coding agent to improve the agent you&apos;re building.
+        </div>
+
+        <div className="mt-3">
+          <div className="font-medium mb-1">How to use:</div>
+          <div className="ml-2 space-y-1 text-xs font-normal">
+            <div className="flex">
+              <span className="mr-1 flex-shrink-0">1.</span>
+              <span className="flex-1 w-full whitespace-pre-wrap break-words">
+                Leave annotations on each completion about what&apos;s working and what isn&apos;t
+              </span>
+            </div>
+            <div className="flex">
+              <span className="mr-1 flex-shrink-0">2.</span>
+              <span className="flex-1 w-full whitespace-pre-wrap break-words">
+                Copy and paste the prompt below into the client&apos;s chat, and fill in the details you&apos;d like to
+                update:
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-3 italic font-bold w-full whitespace-pre-wrap">
+          Adjust anotherai/agent/{agentId} based on the annotations that have been added....[describe the specific
+          improvements you want here]
+        </div>
+      </div>
+
+      <div className="flex gap-2 mt-4 w-full items-center justify-end">
+        <button
+          onClick={handleLearnMore}
+          className="flex items-center gap-1 bg-gray-700 text-white font-bold px-3 py-1.5 rounded-[2px] text-xs hover:bg-gray-800 transition-colors cursor-pointer"
+        >
+          {learnMoreButtonText}
+        </button>
+        <button
+          onClick={handleCopyPrompt}
+          className="flex items-center gap-1 bg-gray-700 text-white font-bold px-3 py-1.5 rounded-[2px] text-xs hover:bg-gray-800 transition-colors cursor-pointer"
+        >
+          {copyButtonText}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Closes:
https://linear.app/anotherai-dev/issue/AAI-59/add-info-button-next-to-add-annotations-button

### Screenshots:
<img width="946" height="846" alt="Screenshot 2025-09-10 at 5 03 13 PM" src="https://github.com/user-attachments/assets/efedaed3-d65e-4f66-bbef-0fa5fab553c7" />
<img width="961" height="969" alt="Screenshot 2025-09-10 at 5 03 19 PM" src="https://github.com/user-attachments/assets/ac0f02a1-65da-42f6-91b2-4ec518df498f" />
<img width="944" height="629" alt="Screenshot 2025-09-10 at 5 03 28 PM" src="https://github.com/user-attachments/assets/25d44268-9faa-418d-9945-193ed352463c" />
