### PR TITLE
Add URL documentation section to foundations.mdx

### DIFF
--- a/docs/content/docs/foundations.mdx
+++ b/docs/content/docs/foundations.mdx
@@ -415,3 +415,27 @@ fmt.Printf("Latency: %fs", latency)
 ```
 </Tab>
 </Tabs>
+
+## URLs
+
+AnotherAI provides direct URLs to view completions and experiments in the web app:
+
+### Completion URL
+To view a specific completion in the web app:
+```
+{{WEB_APP_URL}}/completions/{completion_id}
+```
+
+### Experiment URL
+To view a specific experiment and its results:
+```
+{{WEB_APP_URL}}/experiments/{experiment_id}
+```
+
+### Query Results URL
+When using the `query_completions` MCP tool, it returns a URL in this format:
+```
+{{WEB_APP_URL}}/completions?query={encoded_query}
+```
+
+This URL displays filtered completion results based on your SQL query.

--- a/docs/content/docs/foundations.mdx
+++ b/docs/content/docs/foundations.mdx
@@ -432,6 +432,12 @@ To view a specific experiment and its results:
 {{WEB_APP_URL}}/experiments/{experiment_id}
 ```
 
+### View URL
+To view a specific saved view in the web app:
+```
+{{WEB_APP_URL}}/views/{view_id}
+```
+
 ### Query Results URL
 When using the `query_completions` MCP tool, it returns a URL in this format:
 ```


### PR DESCRIPTION
## Summary
Added a dedicated "URLs" section to the foundations documentation to clearly document how to access completions and experiments in the web app.

## Changes
- Added new "URLs" section at the bottom of `foundations.mdx`
- Documented three URL schemas:
  - **Completion URL**: `{{WEB_APP_URL}}/completions/{completion_id}` - Direct link to view a specific completion
  - **Experiment URL**: `{{WEB_APP_URL}}/experiments/{experiment_id}` - Direct link to view experiment results
  - **Query Results URL**: `{{WEB_APP_URL}}/completions?query={encoded_query}` - URL format returned by query_completions tool

## Context
Previously, these URL schemas were not formally documented anywhere in the documentation. The experiment URL was only mentioned inline in workflow instructions, and the completion URL schema was completely undocumented. This change provides users with a clear reference for constructing URLs to view their completions and experiments.

🤖 Generated with [Claude Code](https://claude.ai/code)