### PR TITLE
Expose experiment updated_at field in API

### DIFF
--- a/backend/protocol/api/_api_models.py
+++ b/backend/protocol/api/_api_models.py
@@ -426,6 +426,7 @@ class ExperimentItem(BaseModel):
 class Experiment(BaseModel):
     id: str
     created_at: datetime
+    updated_at: datetime | None = Field(description="When the experiment was last updated.")
     author_name: str
     url: str
 

--- a/backend/protocol/api/_services/conversions.py
+++ b/backend/protocol/api/_services/conversions.py
@@ -348,6 +348,7 @@ def experiment_from_domain(
         id=experiment.id,
         agent_id=experiment.agent_id,
         created_at=_sanitize_datetime(experiment.created_at),
+        updated_at=_sanitize_datetime(experiment.updated_at) if experiment.updated_at else None,
         author_name=experiment.author_name,
         title=experiment.title,
         description=experiment.description,

--- a/web/src/app/experiments/sections/table/ExperimentsTable.tsx
+++ b/web/src/app/experiments/sections/table/ExperimentsTable.tsx
@@ -16,7 +16,7 @@ import { ExperimentsTableExperimentCell } from "./ExperimentsTableExperimentCell
 export const EXPERIMENTS_COLUMNS = {
   EXPERIMENT: "Experiment",
   AGENT_ID: "Agent ID",
-  CREATED_AT: "Created at",
+  UPDATED_AT: "Updated at",
   AUTHOR: "Author",
 } as const;
 
@@ -40,7 +40,7 @@ export function ExperimentsTable(props: ExperimentsTableProps) {
       EXPERIMENTS_COLUMNS.EXPERIMENT,
       EXPERIMENTS_COLUMNS.AGENT_ID,
       EXPERIMENTS_COLUMNS.AUTHOR,
-      EXPERIMENTS_COLUMNS.CREATED_AT,
+      EXPERIMENTS_COLUMNS.UPDATED_AT,
     ];
   }, []);
 
@@ -54,7 +54,8 @@ export function ExperimentsTable(props: ExperimentsTableProps) {
       },
       [EXPERIMENTS_COLUMNS.AGENT_ID]: experiment.agent_id,
       [EXPERIMENTS_COLUMNS.AUTHOR]: experiment.author_name,
-      [EXPERIMENTS_COLUMNS.CREATED_AT]: experiment.created_at,
+      // Display the more recent of created_at or updated_at
+      [EXPERIMENTS_COLUMNS.UPDATED_AT]: experiment.updated_at || experiment.created_at,
       _originalExperiment: experiment,
     }));
   }, [experiments]);
@@ -124,7 +125,7 @@ export function ExperimentsTable(props: ExperimentsTableProps) {
               case EXPERIMENTS_COLUMNS.AUTHOR:
                 return <ExperimentsBaseCell key={header} value={value} />;
 
-              case EXPERIMENTS_COLUMNS.CREATED_AT:
+              case EXPERIMENTS_COLUMNS.UPDATED_AT:
                 return <ExperimentsBaseCell key={header} value={value} formatter={formatRelativeDate} />;
 
               default:

--- a/web/src/types/models.ts
+++ b/web/src/types/models.ts
@@ -166,6 +166,7 @@ export interface Completion {
 export interface Experiment {
   id: string;
   created_at: string;
+  updated_at?: string;
   author_name: string;
   title: string;
   description: string;
@@ -311,6 +312,7 @@ export interface PatchViewFolderRequest {
 export interface ExperimentListItem {
   id: string;
   created_at: string;
+  updated_at?: string;
   author_name: string;
   title: string;
   description: string;


### PR DESCRIPTION
## Summary
- Exposes the `updated_at` field from the database in the experiments API
- Updates the frontend experiments table to display "Updated at" instead of "Created at"
- Shows the most recent timestamp between `updated_at` and `created_at`

## Changes
- Added `updated_at` field to the `Experiment` API model
- Updated the `experiment_from_domain` conversion function to include `updated_at`
- Added `updated_at` to frontend TypeScript interfaces (`ExperimentListItem` and `Experiment`)
- Changed the experiments table column from "Created at" to "Updated at"
- The table now displays whichever is more recent: `updated_at` or `created_at`

## Test plan
- [ ] Verify that the experiments table shows the "Updated at" column
- [ ] Check that experiments display the correct timestamp (most recent between created/updated)
- [ ] Test that updating an experiment (e.g., setting result) updates the timestamp
- [ ] Ensure backward compatibility for experiments without `updated_at`

🤖 Generated with [Claude Code](https://claude.ai/code)