### PR TITLE
Fix missing reasoning_token_count and cached_token_count in API responses

### DIFF
--- a/backend/protocol/api/_services/conversions.py
+++ b/backend/protocol/api/_services/conversions.py
@@ -666,6 +666,8 @@ def usage_from_domain(usage: DomainInferenceUsage) -> InferenceUsage:
         completion=CompletionUsage(
             text_token_count=usage.completion.text_token_count,
             cost_usd=usage.completion.cost_usd,
+            cached_token_count=usage.completion.cached_token_count,
+            reasoning_token_count=usage.completion.reasoning_token_count,
         ),
     )
 
@@ -683,6 +685,8 @@ def usage_to_domain(usage: InferenceUsage) -> DomainInferenceUsage:
         completion=DomainCompletionUsage(
             text_token_count=usage.completion.text_token_count,
             cost_usd=usage.completion.cost_usd,
+            cached_token_count=usage.completion.cached_token_count,
+            reasoning_token_count=usage.completion.reasoning_token_count,
         ),
     )
 


### PR DESCRIPTION
## Summary
- Fixed missing `reasoning_token_count` and `cached_token_count` fields in the `/v1/completions/{id}` API response
- These fields were being stored in the database but not returned in the API due to missing conversion logic

## Problem
The API endpoint `/v1/completions/{id}` was not returning all trace usage information. Specifically, the `reasoning_token_count` and `cached_token_count` fields were missing from the completion usage data in traces, even though they were present in the raw database query results.

## Solution
Updated the `usage_from_domain` and `usage_to_domain` conversion functions in `backend/protocol/api/_services/conversions.py` to include the missing fields when converting `CompletionUsage` objects between domain and API models.

## Testing
The fix ensures that API responses now include all token count fields, matching what's returned by the `query_completions` endpoint.

@guillaq - Could you please review this fix?

-- Claude Code

🤖 Generated with [Claude Code](https://claude.ai/code)