### PR TITLE
Add explicit usage instruction to create_or_update_view MCP tool

### DIFF
--- a/backend/protocol/api/_mcp.py
+++ b/backend/protocol/api/_mcp.py
@@ -517,6 +517,8 @@ async def get_view(id: str) -> View:
     description=f"""Create a new view or update an existing view. If no dashboard id is provided, the "default" dashboard is used.  # nosec B608
 If a dashboard with the provided id does not exist, it will be created.
 
+**IMPORTANT: Only use this tool when the user explicitly asks to create or update a view. Do not proactively create views without user request.**
+
 **Best Practice**: Avoid using `SELECT *` in your queries as it returns all 40+ columns. Instead:
 1. First use `query_completions('DESCRIBE TABLE completions')` to see all available fields
 2. Select only the fields relevant to your use case


### PR DESCRIPTION
## Summary
- Added clear documentation to the `create_or_update_view` MCP tool that it should only be used when explicitly requested by the user
- This prevents MCP clients from proactively creating views without user request

## Changes
- Updated the description of `create_or_update_view` in `/backend/protocol/api/_mcp.py` to include:
  - **"IMPORTANT: Only use this tool when the user explicitly asks to create or update a view. Do not proactively create views without user request."**

## Context
This change ensures that MCP clients understand that view creation/updates should be user-initiated actions, not proactive suggestions from the assistant.

-- Claude Code

🤖 Generated with [Claude Code](https://claude.ai/code)