### PR TITLE
Fix bug: add_inputs_to_experiment should only create completions for new inputs

### DIFF
--- a/backend/protocol/api/_services/playground_service.py
+++ b/backend/protocol/api/_services/playground_service.py
@@ -142,7 +142,7 @@ class PlaygroundService:
             await self._start_experiment_completions(
                 experiment_id,
                 version_ids=(v.id for v in experiment.versions),
-                input_ids=(input.id for input in domain_inputs),
+                input_ids=inserted_ids,
             )
 
         return [IDType.INPUT.wrap(id) for id in inserted_ids]


### PR DESCRIPTION
## Summary
Fixed a bug in the `add_inputs_to_experiment` method where completions were being created for all provided inputs instead of only the newly inserted ones.

## The Problem
When adding inputs to an existing experiment that already has some inputs:
1. The storage layer correctly returns only the IDs of newly inserted inputs (skipping duplicates)
2. But the code was passing ALL input IDs to create completions, not just the new ones
3. This caused attempts to create duplicate completions for existing inputs
4. Result: When calling `get_experiment`, the new completions weren't properly created

## The Fix
Changed line 145 in `playground_service.py` from:
```python
input_ids=(input.id for input in domain_inputs),  # Bug: uses all inputs
```
to:
```python
input_ids=inserted_ids,  # Fixed: only uses newly inserted input IDs
```

This ensures completions are only created for inputs that were actually added to the experiment.

## Impact
- Fixes the issue where adding new inputs to an existing experiment with versions wouldn't properly create completions
- Prevents unnecessary attempts to create duplicate completions
- Ensures `get_experiment` returns the expected completions after adding new inputs

-- Claude Code

🤖 Generated with [Claude Code](https://claude.ai/code)