### PR TITLE
[AAI-91] number of total completions on overview page doesn't match total completions count on detail page

### DIFF
--- a/web/src/app/agents/sections/table/AgentsTable.tsx
+++ b/web/src/app/agents/sections/table/AgentsTable.tsx
@@ -25,7 +25,7 @@ interface Agent {
 }
 
 interface AgentStats {
-  completions_last_7_days: number;
+  total_completions: number;
   completions_last_3_days: number;
   total_cost: number;
   active: boolean;
@@ -62,7 +62,7 @@ export function AgentsTable(props: AgentsTableProps) {
           name: agent.name && agent.name.trim() ? agent.name : agent.id,
           completionsLast3Days: stats?.completions_last_3_days ?? 0,
         },
-        [AGENTS_COLUMNS.COMPLETIONS_LAST_7_DAYS]: stats?.completions_last_7_days ?? null,
+        [AGENTS_COLUMNS.COMPLETIONS_LAST_7_DAYS]: stats?.total_completions ?? null,
         [AGENTS_COLUMNS.TOTAL_COST]: stats?.total_cost ?? null,
         [AGENTS_COLUMNS.CREATED_AT]: agent.created_at,
         _originalAgent: agent,


### PR DESCRIPTION
### Closes:
https://linear.app/anotherai-dev/issue/AAI-91/number-of-total-completions-on-overview-page-doesnt-match-total

### Screenshots:
<img width="1529" height="1239" alt="Screenshot 2025-09-23 at 10 25 12 AM" src="https://github.com/user-attachments/assets/c0118ae6-91b9-4a8b-ac3b-7616370af0c4" />
<img width="1573" height="1283" alt="Screenshot 2025-09-23 at 10 25 16 AM" src="https://github.com/user-attachments/assets/9a7d8854-8dd5-41bc-94f3-05077ddf915e" />
