### PR TITLE
docs: Add Contact Us section to foundations documentation

### DIFF
--- a/docs/content/docs/foundations.mdx
+++ b/docs/content/docs/foundations.mdx
@@ -421,6 +421,16 @@ fmt.Printf("Latency: %fs", latency)
 </Tab>
 </Tabs>
 
+## Contact Us
+
+Need help or have questions about AnotherAI? We're here to support you through multiple channels:
+
+- **Email**: [team@workflowai.support](mailto:team@workflowai.support)
+- **Slack Community**: [Join our Slack](https://join.slack.com/t/anotherai-dev/shared_invite/zt-3av2prezr-Lz10~8o~rSRQE72m_PyIJA)
+- **GitHub**: [github.com/anotherai-dev/anotherai](https://github.com/anotherai-dev/anotherai) - Feel free to create issues for bug reports, feature requests, or questions
+
+Whether you're getting started, troubleshooting an issue, or looking to discuss advanced use cases, our team and community are ready to help.
+
 ## URLs
 
 AnotherAI provides direct URLs to view completions and experiments in the web app:


### PR DESCRIPTION
## Summary
- Added a new "Contact Us" section to the foundations.mdx documentation
- Provides users with clear support channels and ways to engage with the AnotherAI team

## Changes
- Added Contact Us section with:
  - Support email (team@workflowai.support)
  - Slack community invite link
  - GitHub repository link with explicit encouragement to create issues for bug reports, feature requests, or questions

## Context
This change makes it easier for users to find help and contribute feedback by consolidating all contact methods in the main foundations documentation.

-- Claude Code

🤖 Generated with [Claude Code](https://claude.ai/code)