### PR TITLE
docs: add hosted version URLs to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,9 @@
+## Hosted Version
+
+AnotherAI is available hosted at:
+- Web App: https://anotherai.dev
+- API: https://api.anotherai.dev
+
 ## Running AnotherAI Locally
 
 Ensure `.env` file exists with required API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.)


### PR DESCRIPTION
## Summary
- Added hosted version information to CLAUDE.md
- Web app URL: https://anotherai.dev
- API URL: https://api.anotherai.dev

## Changes
Added a new "Hosted Version" section at the top of CLAUDE.md with the production URLs for both the web application and API.

🤖 Generated with [Claude Code](https://claude.ai/code)