### PR TITLE
docs: Add feedback to WorkflowAI migration guide

### DIFF
--- a/docs/content/docs/use-cases/migrate-from-workflowai.mdx
+++ b/docs/content/docs/use-cases/migrate-from-workflowai.mdx
@@ -18,7 +18,7 @@ WorkflowAI and AnotherAI share the same authorization servers. So users of Workf
 
 ## Migration Steps
 
-Very important: Most WorkflowAI agents use deployments on WorkflowAI, meaning that the code does not contain the prompt. The prompt is stored and managed by the WorkflowAI backend. It is possible to setup a bridge that forwards data from WorkflowAI to AnotherAI which makes the prompt and/or deployment available in AnotherAI.
+Very important: [FEEDBACK: "ALL?"": because using version by number also means no prompt]... Most WorkflowAI agents use deployments on WorkflowAI, meaning that the code does not contain the prompt. The prompt is stored and managed by the WorkflowAI backend. It is possible to setup a bridge that forwards data from WorkflowAI to AnotherAI which makes the prompt and/or deployment available in AnotherAI.
 
 ### Step 1: Identify the agent id and deployment environment
 
@@ -61,8 +61,10 @@ const analyzeBookCharacters: Agent<
 > = workflowAI.agent({
   id: "analyze-book-characters", // agent id, will be the same in AnotherAI
   schemaId: 1, // schema id, can be ignored, will no longer be used in AnotherAI
-  version: "production", // deployment envoronment, in WorkflowAI deployments are unique per agent schema
+  version: "10.1", // deployment envoronment, in WorkflowAI deployments are unique per agent schema
 });
+
+[SUGGESTION: CAN WE ADD METADATA LIKE `workflowai.version` TO IMPORTED COMPLETIONS, so that the AI assistant can fetch the completion that match this version? and then update the code]
 ```
 
 </Tab>


### PR DESCRIPTION
## Summary
- Added feedback comments from Pierre on the WorkflowAI migration documentation
- Questions and suggestions for improvement inline in the docs

## Changes
- Question about "ALL" agents using deployments when version by number also means no prompt
- Suggestion to add `workflowai.version` metadata to imported completions for better migration support
- Updated example to show version number (10.1) instead of "production" for clarity

## For @anyacherniss 
These are draft feedback comments added directly to the migration guide for your review.

🤖 Generated with [Claude Code](https://claude.ai/code)