### PR TITLE
Fix: Add pagination to metadata click queries

### DIFF
--- a/web/src/components/completion-modal/MetadataView.tsx
+++ b/web/src/components/completion-modal/MetadataView.tsx
@@ -31,7 +31,7 @@ export function MetadataView({ metadata }: Props) {
   const handleMetadataClick = useCallback(
     (key: string, value: unknown) => {
       const stringValue = typeof value === "string" ? value : JSON.stringify(value);
-      const query = `SELECT * FROM completions WHERE metadata['${key}'] = '${stringValue}'`;
+      const query = `SELECT * FROM completions WHERE metadata['${key}'] = '${stringValue}' ORDER BY created_at DESC LIMIT {limit} OFFSET {offset}`;
       const encodedQuery = encodeURIComponent(query);
       router.push(`/completions?newQuery=${encodedQuery}`);
     },


### PR DESCRIPTION
## Summary
- Adds LIMIT and OFFSET placeholders to SQL queries generated when clicking on metadata fields in the completion details view
- Prevents potential performance issues with unbounded result sets

## Problem
When users click on metadata fields in the completion details modal (e.g., `agent_id` or `user_id`), the generated SQL query was missing pagination controls, which could result in fetching all matching completions without limit.

## Solution
Updated the `MetadataView` component to include `ORDER BY created_at DESC LIMIT {limit} OFFSET {offset}` in the generated query, matching the pattern used in the main completions page.

## Additional Work Needed
There may be other queries in the codebase that could benefit from similar pagination updates. A broader review of SQL queries across the application would help identify any other cases where unbounded result sets could cause performance issues.

## Test Plan
- [x] Click on metadata fields in completion details modal
- [x] Verify the generated URL includes pagination placeholders
- [x] Confirm the completions page correctly processes the pagination variables

🤖 Generated with [Claude Code](https://claude.ai/code)