### PR TITLE
Add api_host field to create_api_key response

### DIFF
--- a/backend/protocol/api/_api_models.py
+++ b/backend/protocol/api/_api_models.py
@@ -793,6 +793,7 @@ class APIKey(BaseModel):
 
 class CompleteAPIKey(APIKey):
     key: str
+    api_host: str
 
 
 class CreateAPIKeyRequest(BaseModel):

--- a/backend/protocol/api/_services/conversions.py
+++ b/backend/protocol/api/_services/conversions.py
@@ -5,6 +5,7 @@ from pydantic import TypeAdapter
 from pydantic_core import ValidationError
 from structlog import get_logger
 
+from core.consts import ANOTHERAI_API_URL
 from core.domain.agent import Agent as DomainAgent
 from core.domain.agent_completion import AgentCompletion as DomainCompletion
 from core.domain.agent_input import AgentInput as DomainInput
@@ -748,6 +749,7 @@ def api_key_from_domain_complete(api_key: DomainCompleteAPIKey) -> CompleteAPIKe
         last_used_at=api_key.last_used_at,
         created_by=api_key.created_by,
         key=api_key.api_key,
+        api_host=ANOTHERAI_API_URL,
     )
 
 


### PR DESCRIPTION
Add api_host field to the response returned by the create_api_key endpoint.

## Changes
- Added `api_host` field to `CompleteAPIKey` model
- Updated conversion function to include API host URL
- Uses `ANOTHERAI_API_URL` environment variable

Resolves #133

Generated with [Claude Code](https://claude.ai/code)