### PR TITLE
Remove icon_url from MCP list_models tool response only

### DIFF
--- a/backend/protocol/api/_api_models.py
+++ b/backend/protocol/api/_api_models.py
@@ -646,6 +646,43 @@ class Model(BaseModel):
     )
 
 
+class MCPModel(BaseModel):
+    """Model information for MCP tool responses, excluding icon_url to reduce context window usage."""
+
+    id: str = Field(
+        description="Unique identifier for the model, which should be used in the `model` parameter of the OpenAI API.",
+    )
+    display_name: str = Field(
+        description="Human-readable name for the model.",
+    )
+
+    supports: ModelSupports = Field(
+        description="Detailed information about what the model supports.",
+    )
+
+    pricing: ModelPricing = Field(
+        description="Pricing information for the model.",
+    )
+
+    release_date: date = Field(
+        description="The date the model was released on the WorkflowAI platform.",
+    )
+
+    reasoning: ModelReasoning | None = Field(
+        default=None,
+        description="Reasoning configuration for the model. None if the model does not support reasoning.",
+    )
+
+    context_window: ModelContextWindow = Field(
+        description="Context window and output token limits for the model.",
+    )
+
+    speed_index: float = Field(
+        description="An indication of speed of the model, the higher the index, the faster the model. "
+        "The index is calculated from the model's average tokens-per-second rate on a standardized translation task.",
+    )
+
+
 # ----------------------------------------
 # Views
 

--- a/backend/protocol/api/_mcp.py
+++ b/backend/protocol/api/_mcp.py
@@ -1,11 +1,10 @@
 # ruff: noqa: B008
 # pyright: reportCallInDefaultInitializer=false
 
-from datetime import date
 from typing import Annotated, Any, Literal
 
 from mcp.types import ToolAnnotations
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from core.consts import ANOTHERAI_API_URL
 from core.domain.cache_usage import CacheUsage
@@ -21,11 +20,8 @@ from protocol.api._api_models import (
     Deployment,
     Experiment,
     Input,
+    MCPModel,
     Model,
-    ModelContextWindow,
-    ModelPricing,
-    ModelReasoning,
-    ModelSupports,
     Page,
     QueryCompletionResponse,
     SearchDocumentationResponse,
@@ -33,43 +29,6 @@ from protocol.api._api_models import (
     View,
 )
 from protocol.api._services import models_service
-
-
-class MCPModel(BaseModel):
-    """Model information for MCP tool responses, excluding icon_url to reduce context window usage."""
-
-    id: str = Field(
-        description="Unique identifier for the model, which should be used in the `model` parameter of the OpenAI API.",
-    )
-    display_name: str = Field(
-        description="Human-readable name for the model.",
-    )
-
-    supports: ModelSupports = Field(
-        description="Detailed information about what the model supports.",
-    )
-
-    pricing: ModelPricing = Field(
-        description="Pricing information for the model.",
-    )
-
-    release_date: date = Field(
-        description="The date the model was released on the WorkflowAI platform.",
-    )
-
-    reasoning: ModelReasoning | None = Field(
-        default=None,
-        description="Reasoning configuration for the model. None if the model does not support reasoning.",
-    )
-
-    context_window: ModelContextWindow = Field(
-        description="Context window and output token limits for the model.",
-    )
-
-    speed_index: float = Field(
-        description="An indication of speed of the model, the higher the index, the faster the model. "
-        "The index is calculated from the model's average tokens-per-second rate on a standardized translation task.",
-    )
 
 
 def _convert_model_for_mcp(model: Model) -> MCPModel:

--- a/backend/protocol/api/_services/conversions_test.py
+++ b/backend/protocol/api/_services/conversions_test.py
@@ -22,6 +22,7 @@ from protocol.api._api_models import (
     ToolCallRequest,
     ToolCallResult,
 )
+from protocol.api._mcp import _convert_model_for_mcp
 from protocol.api._services.conversions import (
     _extract_json_schema,
     annotation_to_domain,
@@ -786,7 +787,6 @@ class TestMCPModelConversion:
             ModelSupports,
             SupportsModality,
         )
-        from protocol.api._mcp import _convert_model_for_mcp
 
         # Create a full API model with icon_url
         api_model = Model(
@@ -797,14 +797,14 @@ class TestMCPModelConversion:
                 input=SupportsModality(text=True, image=False, audio=False, pdf=False),
                 output=SupportsModality(text=True, image=False, audio=False, pdf=False),
                 parallel_tool_calls=False,
-                response_format=False,
                 tools=False,
+                top_p=True,
                 temperature=True,
             ),
             pricing=ModelPricing(input_token_usd=0.001, output_token_usd=0.002),
             release_date=date(2024, 1, 1),
             reasoning=None,
-            context_window=ModelContextWindow(max_input_tokens=4096, max_output_tokens=1024),
+            context_window=ModelContextWindow(max_tokens=4096, max_output_tokens=1024),
             speed_index=1.0,
         )
 
@@ -823,7 +823,7 @@ class TestMCPModelConversion:
 
         # Verify icon_url is not present in MCP model
         assert not hasattr(mcp_model, "icon_url")
-        
+
         # Verify the MCP model doesn't include icon_url in its serialized form
         mcp_model_dict = mcp_model.model_dump()
         assert "icon_url" not in mcp_model_dict


### PR DESCRIPTION
Closes #363

## Summary
Removes the `icon_url` field from the MCP `list_models` tool response to reduce context window usage, while keeping it in API responses.

## Changes
- Create `MCPModel` class without `icon_url` field for MCP tool responses
- Keep `icon_url` in API responses (Model class unchanged)
- Add conversion function `_convert_model_for_mcp` to exclude `icon_url`
- Update `list_models` MCP tool to use `MCPModel` instead of `Model`
- Add test to verify `icon_url` exclusion in MCP responses

## Technical Details
This approach allows us to:
1. Reduce context window usage for MCP clients by excluding unnecessary `icon_url` data
2. Maintain full backward compatibility with existing API consumers
3. Keep the codebase clean with a targeted solution

Generated with [Claude Code](https://claude.ai/code)