### PR TITLE
[GitHub-370] Add Deployment ID as the first row in Table on Deployment Page

### DIFF
--- a/web/src/app/deployments/[id]/components/DeploymentInfoSection.tsx
+++ b/web/src/app/deployments/[id]/components/DeploymentInfoSection.tsx
@@ -43,6 +43,12 @@ export function DeploymentInfoSection({ deployment }: DeploymentInfoSectionProps
   const deploymentRows = useMemo(
     () => [
       {
+        label: "Deployment ID",
+        value: deployment.id,
+        copyValue: `anotherai/deployment/${deployment.id}`,
+        copyLabel: "Deployment ID",
+      },
+      {
         label: "Agent ID",
         value: deployment.agent_id,
         copyValue: `anotherai/agent/${deployment.agent_id}`,
@@ -59,7 +65,7 @@ export function DeploymentInfoSection({ deployment }: DeploymentInfoSectionProps
         value: formatDate(deployment.created_at, "relative_with_time"),
       },
     ],
-    [deployment.agent_id, deployment.version.id, deployment.created_at]
+    [deployment.id, deployment.agent_id, deployment.version.id, deployment.created_at]
   );
 
   const basicVersionRows = useMemo(


### PR DESCRIPTION
### Closes:
https://github.com/anotherai-dev/anotherai/issues/370

### Screenshot:
<img width="1840" height="1282" alt="Screenshot 2025-10-01 at 5 14 57 PM" src="https://github.com/user-attachments/assets/22d73072-cf98-4852-8edd-01b6d3bc7794" />
