### PR TITLE
ci: update Claude workflow to use claude-sonnet-4-5-20250929

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,8 +49,8 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Optional: Specify model (defaults to Claude Sonnet 4)
+          model: "claude-sonnet-4-5-20250929"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary
- Updated the Claude Code GitHub workflow to use the latest Sonnet 4.5 model (`claude-sonnet-4-5-20250929`)

Fixes #399

@guillaq Please review

🤖 Generated with [Claude Code](https://claude.com/claude-code)