### PR TITLE
ci: upgrade Claude Code action from beta to v1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,23 +34,18 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          allowed_tools: |
-            Bash(git checkout)
-            Bash(pip)
-            Bash(python)
-            Bash(uv run ruff check)
-            Bash(uv run pyright)
-            Bash(gh)
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
 
-          # Optional: Specify model (defaults to Claude Sonnet 4)
-          model: "claude-sonnet-4-5-20250929"
+          # Optional: Specify model and other CLI options via claude_args
+          claude_args: |
+            --model claude-opus-4-20250514
+            --allowedTools "Bash(git checkout)" "Bash(pip)" "Bash(python)" "Bash(uv run ruff check:*)" "Bash(uv run pyright)" "Bash(gh:*)"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary
- Upgrade Claude Code GitHub Action from `@beta` to `@v1`
- Migrate configuration to new v1 format
- Switch to Claude Opus 4 model

## Changes
- Updated action version: `@beta` → `@v1`
- Moved `model` parameter to `claude_args` with `--model` flag
- Moved `allowed_tools` to `claude_args` with `--allowedTools` flag (using correct space-separated quoted syntax)
- Changed model from Sonnet 4.5 to Opus 4

## Migration Notes
This PR implements the essential changes required for upgrading from beta to v1:
1. ✅ Update action version
2. ✅ Remove old `mode` configuration (not applicable - already auto-detected)
3. ✅ Update to use `claude_args` for CLI options
4. ✅ Move `model` and `allowed_tools` to `claude_args`

🤖 Generated with [Claude Code](https://claude.com/claude-code)