### PR TITLE
ci: add uv installation to Claude Code workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Install uv # UV GitHub integration: https://docs.astral.sh/uv/guides/integration/github/
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
- Add UV package manager installation to the Claude Code GitHub Actions workflow
- Enable caching for UV dependencies

## Changes
- Added `astral-sh/setup-uv@v6` step before running Claude Code
- Enabled UV dependency caching with `enable-cache: true`
- Added reference to UV GitHub integration documentation

## Benefits
- Ensures UV is available for Python dependency management
- Improves workflow performance with caching
- Supports `uv run` commands used in allowed tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)