### PR TITLE
fix: preserve folder_id when updating views via MCP tool

### DIFF
--- a/backend/tests/components/mcp/create_view_test.py
+++ b/backend/tests/components/mcp/create_view_test.py
@@ -59,3 +59,55 @@ async def test_create_view_with_invalid_field(test_api_client: IntegrationTestCl
             },
         )
     assert "validation error for" in str(excinfo.value)
+
+
+async def test_create_or_update_view_preserves_folder(test_api_client: IntegrationTestClient):
+    """Test that updating a view via MCP preserves its folder assignment."""
+    # First, create a folder
+    folder_res = await test_api_client.api_client.post(
+        "/views/folders",
+        json={"name": "Test Folder"},
+    )
+    assert folder_res.status_code == 201
+    folder = folder_res.json()
+    folder_id = folder["id"]
+
+    # Create a view with folder assignment using the API
+    view_res = await test_api_client.api_client.post(
+        "/views",
+        json={
+            "title": "Test View",
+            "query": "SELECT * FROM completions LIMIT 10",
+            "folder_id": folder_id,
+        },
+    )
+    assert view_res.status_code == 201
+    view = view_res.json()
+    view_id = view["id"]
+
+    # Verify the view has the correct folder_id
+    get_res = await test_api_client.api_client.get(f"/views/{view_id}")
+    assert get_res.status_code == 200
+    view_data = get_res.json()
+    assert view_data["folder_id"] == folder_id
+
+    # Update the view using MCP tool (which was resetting the folder)
+    mcp_res = await test_api_client.mcp.call_tool(
+        "create_or_update_view",
+        {
+            "view": {
+                "id": view_id,
+                "title": "Updated Test View",
+                "query": "SELECT * FROM completions LIMIT 20",
+            },
+        },
+    )
+    assert not mcp_res.is_error
+
+    # Verify the folder_id is still preserved after MCP update
+    get_res_after = await test_api_client.api_client.get(f"/views/{view_id}")
+    assert get_res_after.status_code == 200
+    updated_view = get_res_after.json()
+    assert updated_view["folder_id"] == folder_id
+    assert updated_view["title"] == "Updated Test View"
+    assert updated_view["query"] == "SELECT * FROM completions LIMIT 20"


### PR DESCRIPTION
The create_or_update_view MCP tool was resetting folder assignments when updating existing views. This fix modifies create_or_update_mcp to check if a view exists and preserve its folder_id during updates.

- Check if view exists before updating and preserve its folder_id
- Add test to verify folder preservation during MCP view updates
- Use specific ObjectNotFoundError instead of generic Exception
- Add query validation to update path for consistency

Fixes #310

Generated with [Claude Code](https://claude.ai/code)