### PR TITLE
fix: remove icon_url from MCP list_models response while keeping it in API

### DIFF
--- a/backend/protocol/api/_api_models.py
+++ b/backend/protocol/api/_api_models.py
@@ -3,6 +3,7 @@ Do not include validation or conversion logic here. Logic should be included eit
 or in the conversion layer."""
 
 from datetime import date, datetime
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 from uuid import UUID
 
@@ -604,6 +605,15 @@ class ModelContextWindow(BaseModel):
     max_output_tokens: int = Field(
         description="The maximum number of tokens that the model can output.",
     )
+
+
+class ModelField(StrEnum):
+    supports = "supports"
+    pricing = "pricing"
+    reasoning = "reasoning"
+    speed_index = "speed_index"
+    context_window = "context_window"
+    release_date = "release_date"
 
 
 class Model(BaseModel):

--- a/backend/protocol/api/_api_models_test.py
+++ b/backend/protocol/api/_api_models_test.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from core.domain.reasoning_effort import ReasoningEffort
-from protocol.api._api_models import ToolCallResult, Version
+from protocol.api._api_models import Model, ModelField, ToolCallResult, Version
 
 
 class TestVersion:
@@ -50,3 +50,9 @@ class TestToolCallResult:
     def test_empty_payload(self):
         with pytest.raises(ValidationError):
             ToolCallResult.model_validate({"id": "hello"})
+
+
+class TestModelFields:
+    def test_subset_of_model(self):
+        for m in ModelField:
+            assert m.value in Model.model_fields, f"{m.value} not in {Model.model_fields}"

--- a/backend/protocol/api/_mcp.py
+++ b/backend/protocol/api/_mcp.py
@@ -20,7 +20,7 @@ from protocol.api._api_models import (
     Deployment,
     Experiment,
     Input,
-    Model,
+    ModelField,
     Page,
     QueryCompletionResponse,
     SearchDocumentationResponse,
@@ -232,7 +232,9 @@ async def get_experiment(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def list_models() -> list[Model]:
+async def list_models(
+    include: list[ModelField] | None = None,
+) -> list[dict[str, Any]]:
     """List all available AI models with their capabilities, pricing, and metadata.
 
     Returns a list of Model objects containing:
@@ -247,10 +249,10 @@ async def list_models() -> list[Model]:
     - pricing: Cost information per token (input_token_usd, output_token_usd)
     - release_date: When the model was released on the platform
     - reasoning: Optional reasoning configuration with token budgets for different effort levels
-
-    Use this tool before calling playground() to see available model IDs and their capabilities.
+    - context_window: Context window and output token limits for the model.
+    - speed_index: Speed index of the model.
     """
-    return await models_service.list_models_mcp()
+    return await models_service.list_models_mcp(include)
 
 
 # ------------------------------------------------------------

--- a/backend/protocol/api/_mcp.py
+++ b/backend/protocol/api/_mcp.py
@@ -238,7 +238,6 @@ async def list_models() -> list[Model]:
     Returns a list of Model objects containing:
     - id: Model identifier to use in the 'models' parameter of playground/API calls (corresponds to version_model in query_completions)
     - display_name: Human-readable name of the model
-    - icon_url: URL to the model's icon image
     - supports: Capabilities including:
       - input/output modalities (text, image, audio, pdf support)
       - parallel_tool_calls: Whether model can make multiple tool calls in one inference
@@ -251,7 +250,7 @@ async def list_models() -> list[Model]:
 
     Use this tool before calling playground() to see available model IDs and their capabilities.
     """
-    return await models_service.list_models()
+    return await models_service.list_models_mcp()
 
 
 # ------------------------------------------------------------

--- a/backend/protocol/api/_services/conversions.py
+++ b/backend/protocol/api/_services/conversions.py
@@ -588,6 +588,22 @@ def model_response_from_domain(model_id: str, model: FinalModelData) -> Model:
     )
 
 
+def model_response_from_domain_mcp(model_id: str, model: FinalModelData) -> Model:
+    """Convert model data for MCP responses, excluding icon_url to reduce context window usage."""
+    provider_data = model.providers[0][1]
+    return Model(
+        id=model_id,
+        display_name=model.display_name,
+        icon_url="",  # Empty string for MCP responses to reduce context window
+        supports=model_supports_from_domain(model),
+        pricing=model_pricing(provider_data),
+        release_date=model.release_date,
+        reasoning=model_reasoning_from_domain(model.reasoning) if model.reasoning is not None else None,
+        context_window=model_context_window_from_domain(model.max_tokens_data),
+        speed_index=model.speed_index,
+    )
+
+
 def _sanitized_completion_id(completion_id: str) -> UUID:
     return UUID(sanitize_id(completion_id, IDType.COMPLETION))
 

--- a/backend/protocol/api/_services/models_service.py
+++ b/backend/protocol/api/_services/models_service.py
@@ -1,11 +1,14 @@
-from collections.abc import Iterator
-from typing import cast
+from collections.abc import Iterable, Iterator
+from typing import Any, cast
 
 from core.domain.models.model_data import FinalModelData, LatestModel
 from core.domain.models.model_data_mapping import MODEL_DATAS
 from core.domain.models.models import Model as ModelID
-from protocol.api._api_models import Model
-from protocol.api._services.conversions import model_response_from_domain, model_response_from_domain_mcp
+from protocol.api._api_models import Model, ModelField
+from protocol.api._services.conversions import (
+    model_response_filter,
+    model_response_from_domain,
+)
 
 
 def _model_data_iterator() -> Iterator[Model]:
@@ -24,27 +27,10 @@ def _model_data_iterator() -> Iterator[Model]:
         yield model_response_from_domain(model.value, final_data)
 
 
-def _model_data_iterator_mcp() -> Iterator[Model]:
-    """Iterator for MCP responses that excludes icon_url to reduce context window usage."""
-    for model in ModelID:
-        data = MODEL_DATAS[model]
-        final_data: FinalModelData | LatestModel
-        if isinstance(data, LatestModel):
-            final_data = cast(FinalModelData, MODEL_DATAS[data.model])
-        elif isinstance(data, FinalModelData):
-            final_data = data
-        else:
-            # Skipping deprecated models
-            continue
-        if not final_data.providers:
-            continue
-        yield model_response_from_domain_mcp(model.value, final_data)
-
-
 async def list_models() -> list[Model]:
     return list(_model_data_iterator())
 
 
-async def list_models_mcp() -> list[Model]:
+async def list_models_mcp(fields: Iterable[ModelField] | None = None) -> list[dict[str, Any]]:
     """List models for MCP responses, excluding icon_url to reduce context window usage."""
-    return list(_model_data_iterator_mcp())
+    return list(model_response_filter(fields, _model_data_iterator()))

--- a/backend/protocol/api/_services/models_service.py
+++ b/backend/protocol/api/_services/models_service.py
@@ -5,7 +5,7 @@ from core.domain.models.model_data import FinalModelData, LatestModel
 from core.domain.models.model_data_mapping import MODEL_DATAS
 from core.domain.models.models import Model as ModelID
 from protocol.api._api_models import Model
-from protocol.api._services.conversions import model_response_from_domain
+from protocol.api._services.conversions import model_response_from_domain, model_response_from_domain_mcp
 
 
 def _model_data_iterator() -> Iterator[Model]:
@@ -24,5 +24,27 @@ def _model_data_iterator() -> Iterator[Model]:
         yield model_response_from_domain(model.value, final_data)
 
 
+def _model_data_iterator_mcp() -> Iterator[Model]:
+    """Iterator for MCP responses that excludes icon_url to reduce context window usage."""
+    for model in ModelID:
+        data = MODEL_DATAS[model]
+        final_data: FinalModelData | LatestModel
+        if isinstance(data, LatestModel):
+            final_data = cast(FinalModelData, MODEL_DATAS[data.model])
+        elif isinstance(data, FinalModelData):
+            final_data = data
+        else:
+            # Skipping deprecated models
+            continue
+        if not final_data.providers:
+            continue
+        yield model_response_from_domain_mcp(model.value, final_data)
+
+
 async def list_models() -> list[Model]:
     return list(_model_data_iterator())
+
+
+async def list_models_mcp() -> list[Model]:
+    """List models for MCP responses, excluding icon_url to reduce context window usage."""
+    return list(_model_data_iterator_mcp())

--- a/backend/protocol/api/_services/models_service_test.py
+++ b/backend/protocol/api/_services/models_service_test.py
@@ -1,0 +1,74 @@
+"""Test for models service to verify API vs MCP response differences."""
+
+import pytest
+
+from protocol.api._services import models_service
+
+
+@pytest.mark.asyncio
+async def test_list_models_api_includes_icon_url():
+    """Test that API response includes icon_url field."""
+    models = await models_service.list_models()
+
+    assert len(models) > 0, "Should return at least one model"
+
+    # Check that all models have icon_url field with non-empty values
+    for model in models:
+        assert hasattr(model, "icon_url"), f"Model {model.id} should have icon_url field"
+        assert model.icon_url, f"Model {model.id} should have non-empty icon_url"
+        assert model.icon_url.startswith("http"), f"Model {model.id} icon_url should be a valid URL"
+
+
+@pytest.mark.asyncio
+async def test_list_models_mcp_excludes_icon_url():
+    """Test that MCP response excludes icon_url field by setting it to empty string."""
+    models = await models_service.list_models_mcp()
+
+    assert len(models) > 0, "Should return at least one model"
+
+    # Check that all models have icon_url field set to empty string
+    for model in models:
+        assert hasattr(model, "icon_url"), f"Model {model.id} should have icon_url field"
+        assert model.icon_url == "", f"Model {model.id} icon_url should be empty string for MCP"
+
+
+@pytest.mark.asyncio
+async def test_api_and_mcp_have_same_models_except_icon_url():
+    """Test that API and MCP responses have the same models except for icon_url."""
+    api_models = await models_service.list_models()
+    mcp_models = await models_service.list_models_mcp()
+
+    assert len(api_models) == len(mcp_models), "API and MCP should return same number of models"
+
+    # Sort models by ID for comparison
+    api_models_sorted = sorted(api_models, key=lambda m: m.id)
+    mcp_models_sorted = sorted(mcp_models, key=lambda m: m.id)
+
+    for api_model, mcp_model in zip(api_models_sorted, mcp_models_sorted, strict=False):
+        # Check that all fields are the same except icon_url
+        assert api_model.id == mcp_model.id
+        assert api_model.display_name == mcp_model.display_name
+        assert api_model.supports == mcp_model.supports
+        assert api_model.pricing == mcp_model.pricing
+        assert api_model.release_date == mcp_model.release_date
+        assert api_model.reasoning == mcp_model.reasoning
+        assert api_model.context_window == mcp_model.context_window
+        assert api_model.speed_index == mcp_model.speed_index
+
+        # Verify icon_url difference
+        assert api_model.icon_url != "", f"API model {api_model.id} should have icon_url"
+        assert mcp_model.icon_url == "", f"MCP model {mcp_model.id} should have empty icon_url"
+
+
+@pytest.mark.asyncio
+async def test_mcp_response_serialization_no_icon_url():
+    """Test that MCP response when serialized to dict has empty icon_url."""
+    models = await models_service.list_models_mcp()
+
+    assert len(models) > 0, "Should return at least one model"
+
+    # Check serialized form
+    for model in models:
+        model_dict = model.model_dump()
+        assert "icon_url" in model_dict, "Serialized model should have icon_url field"
+        assert model_dict["icon_url"] == "", f"Serialized MCP model {model.id} should have empty icon_url"

--- a/backend/protocol/api/_services/models_service_test.py
+++ b/backend/protocol/api/_services/models_service_test.py
@@ -1,74 +1,13 @@
-"""Test for models service to verify API vs MCP response differences."""
-
-import pytest
-
 from protocol.api._services import models_service
 
 
-@pytest.mark.asyncio
-async def test_list_models_api_includes_icon_url():
-    """Test that API response includes icon_url field."""
+async def test_sanity():
     models = await models_service.list_models()
-
-    assert len(models) > 0, "Should return at least one model"
-
-    # Check that all models have icon_url field with non-empty values
-    for model in models:
-        assert hasattr(model, "icon_url"), f"Model {model.id} should have icon_url field"
-        assert model.icon_url, f"Model {model.id} should have non-empty icon_url"
-        assert model.icon_url.startswith("http"), f"Model {model.id} icon_url should be a valid URL"
+    mcp_model = await models_service.list_models_mcp()
+    assert len(models) == len(mcp_model)
 
 
-@pytest.mark.asyncio
-async def test_list_models_mcp_excludes_icon_url():
-    """Test that MCP response excludes icon_url field by setting it to empty string."""
-    models = await models_service.list_models_mcp()
-
-    assert len(models) > 0, "Should return at least one model"
-
-    # Check that all models have icon_url field set to empty string
-    for model in models:
-        assert hasattr(model, "icon_url"), f"Model {model.id} should have icon_url field"
-        assert model.icon_url == "", f"Model {model.id} icon_url should be empty string for MCP"
-
-
-@pytest.mark.asyncio
-async def test_api_and_mcp_have_same_models_except_icon_url():
-    """Test that API and MCP responses have the same models except for icon_url."""
-    api_models = await models_service.list_models()
-    mcp_models = await models_service.list_models_mcp()
-
-    assert len(api_models) == len(mcp_models), "API and MCP should return same number of models"
-
-    # Sort models by ID for comparison
-    api_models_sorted = sorted(api_models, key=lambda m: m.id)
-    mcp_models_sorted = sorted(mcp_models, key=lambda m: m.id)
-
-    for api_model, mcp_model in zip(api_models_sorted, mcp_models_sorted, strict=False):
-        # Check that all fields are the same except icon_url
-        assert api_model.id == mcp_model.id
-        assert api_model.display_name == mcp_model.display_name
-        assert api_model.supports == mcp_model.supports
-        assert api_model.pricing == mcp_model.pricing
-        assert api_model.release_date == mcp_model.release_date
-        assert api_model.reasoning == mcp_model.reasoning
-        assert api_model.context_window == mcp_model.context_window
-        assert api_model.speed_index == mcp_model.speed_index
-
-        # Verify icon_url difference
-        assert api_model.icon_url != "", f"API model {api_model.id} should have icon_url"
-        assert mcp_model.icon_url == "", f"MCP model {mcp_model.id} should have empty icon_url"
-
-
-@pytest.mark.asyncio
-async def test_mcp_response_serialization_no_icon_url():
-    """Test that MCP response when serialized to dict has empty icon_url."""
-    models = await models_service.list_models_mcp()
-
-    assert len(models) > 0, "Should return at least one model"
-
-    # Check serialized form
-    for model in models:
-        model_dict = model.model_dump()
-        assert "icon_url" in model_dict, "Serialized model should have icon_url field"
-        assert model_dict["icon_url"] == "", f"Serialized MCP model {model.id} should have empty icon_url"
+class TestListModelsMCP:
+    async def test_default_does_not_include_icon_url(self):
+        models = await models_service.list_models_mcp()
+        assert all("icon_url" not in model for model in models)


### PR DESCRIPTION
Fixes #405

## Summary
Remove the `icon_url` field from the `list_models` MCP tool response to reduce context window usage, while keeping it in the API response.

## Changes
- Add `model_response_from_domain_mcp()` that sets `icon_url` to empty string
- Add `list_models_mcp()` function for MCP-specific responses
- Update MCP tool to use `list_models_mcp()` instead of `list_models()`
- Keep `icon_url` in API responses via `list_models()`
- Add comprehensive tests to verify the difference

## Testing
Added comprehensive tests in `models_service_test.py` to ensure:
- The API `list_models` function returns models with valid `icon_url` values
- The MCP `list_models_mcp` function returns models with empty `icon_url` values
- All other model fields remain identical between API and MCP responses
- The serialized MCP model dictionaries have empty `icon_url`

This approach maintains backward compatibility for the API while reducing context window usage for MCP tools.

Generated with [Claude Code](https://claude.ai/code)