### PR TITLE
Add copy functionality to metadata values

### DIFF
--- a/web/src/components/completion-modal/InfoRow.tsx
+++ b/web/src/components/completion-modal/InfoRow.tsx
@@ -9,13 +9,15 @@ type InfoRowProps = {
   copyable?: boolean;
   copyValue?: string; // Optional separate value for copying
   linkTo?: string; // Optional URL to make the value clickable
+  onClick?: () => void; // Optional click handler
 };
 
-function InfoRow({ title, value, copyable = false, copyValue, linkTo }: InfoRowProps) {
+function InfoRow({ title, value, copyable = false, copyValue, linkTo, onClick }: InfoRowProps) {
   const { showToast } = useToast();
   const [isHovered, setIsHovered] = useState(false);
 
-  const handleCopy = async () => {
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation(); // Prevent triggering the row's onClick
     try {
       // Use copyValue if provided, otherwise use display value
       await navigator.clipboard.writeText(copyValue || value);
@@ -61,9 +63,10 @@ function InfoRow({ title, value, copyable = false, copyValue, linkTo }: InfoRowP
 
   return (
     <div
-      className="bg-white border border-gray-200 rounded-[2px] px-2"
+      className={`bg-white border border-gray-200 rounded-[2px] px-2 ${onClick ? "cursor-pointer hover:bg-gray-50" : ""}`}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
+      onClick={onClick}
     >
       {content}
     </div>

--- a/web/src/components/completion-modal/MetadataView.tsx
+++ b/web/src/components/completion-modal/MetadataView.tsx
@@ -1,26 +1,7 @@
 import { useRouter } from "next/navigation";
 import { memo, useCallback } from "react";
 import { buildQuery } from "../../utils/queries";
-
-type InfoRowProps = {
-  title: string;
-  value: string;
-  onClick?: () => void;
-};
-
-const InfoRow = memo(function InfoRow({ title, value, onClick }: InfoRowProps) {
-  return (
-    <div
-      className={`bg-white border border-gray-200 rounded-[2px] p-2 ${onClick ? "cursor-pointer hover:bg-gray-50 hover:border-gray-300" : ""}`}
-      onClick={onClick}
-    >
-      <div className="flex justify-between items-center">
-        <span className="text-xs font-medium text-gray-700">{title}</span>
-        <span className="text-xs text-gray-900 text-right">{value}</span>
-      </div>
-    </div>
-  );
-});
+import InfoRow from "./InfoRow";
 
 type Props = {
   metadata: Record<string, unknown>;
@@ -54,6 +35,7 @@ function MetadataView({ metadata }: Props) {
             title={key}
             value={typeof value === "string" ? value : JSON.stringify(value)}
             onClick={() => handleMetadataClick(key, value)}
+            copyable={true}
           />
         ))}
       </div>


### PR DESCRIPTION
Fixes #395

## Summary
This PR adds copy functionality to metadata values while maintaining the existing click-to-filter behavior.

## Changes
- Updated shared InfoRow component to support both onClick and copyable props
- Added event.stopPropagation() to copy button to prevent triggering row click
- Replaced local InfoRow implementation in MetadataView with shared component
- Added copyable=true to all metadata values

## Behavior
- Clicking on a metadata value navigates to filtered view (existing behavior)
- Hovering shows a copy button (new)
- Clicking the copy button copies the value to clipboard (new)

Generated with [Claude Code](https://claude.ai/code)