### PR TITLE
Remove model specification from Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,7 +49,6 @@ jobs:
 
           # Optional: Specify model and other CLI options via claude_args
           claude_args: |
-            --model claude-opus-4-20250514
             --allowedTools "Bash(git checkout)" "Bash(pip)" "Bash(python)" "Bash(uv run ruff check:*)" "Bash(uv run pyright)" "Bash(gh:*)"
 
           # Optional: Customize the trigger phrase (default: @claude)


### PR DESCRIPTION
## Summary
- Remove explicit model specification (`claude-opus-4-20250514`) from Claude workflow
- Let the action use its default model instead

## Test plan
- [ ] Verify workflow runs successfully with default model
- [ ] Check that Claude Code action still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)