### PR TITLE
Fix annotations

### DIFF
--- a/backend/core/domain/experiment.py
+++ b/backend/core/domain/experiment.py
@@ -55,8 +55,6 @@ class Experiment(BaseModel):
 
     use_cache: CacheUsage | None = None
 
-    run_ids: list[str] = Field(default_factory=list)
-
     annotations: list[Annotation] = Field(default_factory=list)
 
     metadata: dict[str, Any] | None = None

--- a/backend/core/storage/clickhouse/_models/_ch_experiment.py
+++ b/backend/core/storage/clickhouse/_models/_ch_experiment.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -13,7 +12,6 @@ class ClickhouseExperiment(BaseModel):
     title: str
     description: str
     result: str | None
-    completion_ids: list[UUID]
     agent_id: str
     metadata: dict[str, str]
 
@@ -26,7 +24,6 @@ class ClickhouseExperiment(BaseModel):
             title=experiment.title,
             description=experiment.description,
             result=experiment.result,
-            completion_ids=[UUID(r) for r in experiment.run_ids],
             agent_id=experiment.agent_id,
             metadata=experiment.metadata or {},
         )

--- a/backend/core/storage/clickhouse/clickhouse_client.py
+++ b/backend/core/storage/clickhouse/clickhouse_client.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 from typing import Any, NamedTuple, cast, final, override
 from uuid import UUID
 
@@ -63,22 +63,24 @@ class ClickhouseClient(CompletionStorage):
         await self._insert("experiments", stored_model, settings)
 
     @override
-    async def add_completion_to_experiment(
+    async def add_completions_to_experiment(
         self,
         experiment_id: str,
-        completion_id: UUID,
+        completion_ids: Collection[UUID],
         settings: dict[str, Any] | None = None,
     ):
         # Use ALTER TABLE to update the completion_ids array
         # Since we're using ReplacingMergeTree, we need to update the updated_at as well
+        # Convert UUIDs to strings as clickhouse_connect expects string representation
+        completion_ids_str = [str(uuid) for uuid in completion_ids]
         await self._client.command(
             """
             ALTER TABLE experiments UPDATE
-                completion_ids = arrayDistinct(arrayConcat(completion_ids, [{completion_id:UUID}]))
+                completion_ids = arrayDistinct(arrayConcat(completion_ids, {completion_ids:Array(UUID)}))
             WHERE id = {experiment_id:String}
             """,
             parameters={
-                "completion_id": completion_id,
+                "completion_ids": completion_ids_str,
                 "experiment_id": experiment_id,
             },
             settings=settings or {},

--- a/backend/core/storage/clickhouse/clickhouse_client_test.py
+++ b/backend/core/storage/clickhouse/clickhouse_client_test.py
@@ -18,7 +18,6 @@ from core.domain.agent_output import AgentOutput
 from core.domain.annotation import Annotation
 from core.domain.error import Error
 from core.domain.exceptions import InvalidQueryError, ObjectNotFoundError
-from core.domain.experiment import Experiment
 from core.domain.message import Message
 from core.domain.version import Version
 from core.storage.clickhouse._models._ch_annotation import ClickhouseAnnotation
@@ -351,15 +350,14 @@ async def _load_file[D: BaseModel](
     clickhouse_client: AsyncClient,
     table: str,
     file: str,
-    domain_model: type[D],
-    conversion: Callable[[int, D], BaseModel],
+    model: type[BaseModel],
 ):
     _ = await clickhouse_client.command(f"TRUNCATE TABLE {table}")
     fixture: list[dict[str, Any]] = fixtures_json(f"clickhouse/{file}.json")
-    domain_models = [domain_model.model_validate(raw) for raw in fixture]
-    models = [conversion(1, model) for model in domain_models]
+
+    models = [model.model_validate({**raw, "tenant_uid": 1}) for raw in fixture]
     # Also duplicating for tenant_uid 2
-    models.append(conversion(2, domain_models[0]))
+    models.append(model.model_validate({**fixture[0], "tenant_uid": 2}))
 
     _, columns = data_and_columns(models[0], exclude_none=False)
     all_datas = [data_and_columns(model, exclude_none=False)[0] for model in models]
@@ -369,33 +367,28 @@ async def _load_file[D: BaseModel](
         data=all_datas,
         settings={"async_insert": 1, "wait_for_async_insert": 1},
     )
-    return domain_models
 
 
 class TestRawQuery:
     @pytest.fixture(scope="class")
     async def query_fn(self, clickhouse_client: AsyncClient):
-        # Truncate all tables
-        _ = await _load_file(
+        await _load_file(
             clickhouse_client,
             "completions",
             "completions",
-            AgentCompletion,
-            ClickhouseCompletion.from_domain,
+            ClickhouseCompletion,
         )
-        _ = await _load_file(
+        await _load_file(
             clickhouse_client,
             "annotations",
             "annotations",
-            Annotation,
-            ClickhouseAnnotation.from_domain,
+            ClickhouseAnnotation,
         )
-        _ = await _load_file(
+        await _load_file(
             clickhouse_client,
             "experiments",
             "experiments",
-            Experiment,
-            ClickhouseExperiment.from_domain,
+            ClickhouseExperiment,
         )
 
         async def query_fn(query: str, tenant_uid: int = 1):
@@ -527,8 +520,7 @@ class TestRawQuery:
         query_str = """
         SELECT c.id, c.output_preview
         FROM completions c
-        JOIN experiments e ON has(e.completion_ids, c.id)
-        WHERE e.id = 'exp-billing-analysis'
+        WHERE c.experiment_id = 'exp-billing-analysis'
         """
         result = await query_fn(query_str)
         assert len(result) == 1
@@ -555,23 +547,6 @@ class TestRawQuery:
         assert result[1]["quality_score"] == 8.1  # methodology_score from ann-006
         assert result[1]["agent_id"] == "data-analysis-agent"
 
-    async def test_experiments_with_completion_count(self, query_fn: Callable[[str], Awaitable[list[dict[str, Any]]]]):
-        """Get experiments with their completion counts"""
-        query_str = """
-        SELECT e.id, e.agent_id, length(e.completion_ids) as completion_count
-        FROM experiments e
-        ORDER BY completion_count DESC, e.id
-        """
-        result = await query_fn(query_str)
-        assert len(result) == 4
-        # Multi-agent experiment should have the most completions (3)
-        assert result[0]["id"] == "exp-multi-agent-comparison"
-        assert result[0]["completion_count"] == 3
-        # Other experiments should have 1 completion each, ordered by id
-        assert result[1]["completion_count"] == 1
-        assert result[2]["completion_count"] == 1
-        assert result[3]["completion_count"] == 1
-
     async def test_completions_with_security_annotations(
         self,
         query_fn: Callable[[str], Awaitable[list[dict[str, Any]]]],
@@ -594,30 +569,18 @@ class TestRawQuery:
         """Calculate average quality metrics per experiment"""
         query_str = """
         SELECT
-            e.id as experiment_id,
-            e.agent_id,
+            experiment_id,
+            c.agent_id,
             AVG(a.metric_value_float) as avg_quality_score,
             COUNT(a.id) as annotation_count
-        FROM experiments e
-        JOIN completions c ON has(e.completion_ids, c.id)
+        FROM completions c
         JOIN annotations a ON c.id = a.completion_id
         WHERE a.metric_value_float IS NOT NULL
-        GROUP BY e.id, e.agent_id
+        GROUP BY experiment_id, agent_id
         ORDER BY avg_quality_score DESC
         """
         result = await query_fn(query_str)
-        assert len(result) == 4
-        # Should include experiments with numeric metrics, ordered by avg score descending
-        # The actual values depend on which annotations belong to which experiments
-        for row in result:
-            assert row["avg_quality_score"] > 0
-            assert row["annotation_count"] > 0
-            assert row["experiment_id"] in [
-                "exp-billing-analysis",
-                "exp-code-quality",
-                "exp-data-analysis",
-                "exp-multi-agent-comparison",
-            ]
+        assert len(result) == 3
 
     async def test_recent_annotations_with_completion_context(
         self,
@@ -655,12 +618,11 @@ class TestRawQuery:
         SELECT DISTINCT
             c.id,
             c.agent_id,
-            e.id as experiment_id,
+            c.experiment_id,
             COUNT(a.id) as annotation_count
         FROM completions c
-        JOIN experiments e ON has(e.completion_ids, c.id)
         JOIN annotations a ON c.id = a.completion_id
-        GROUP BY c.id, c.agent_id, e.id
+        GROUP BY c.id, c.agent_id, c.experiment_id
         ORDER BY annotation_count DESC, c.id
         """
         result = await query_fn(query_str)
@@ -695,7 +657,7 @@ SELECT
     input_messages
 FROM completions
 WHERE
-    id IN (SELECT arrayJoin(completion_ids) FROM experiments WHERE id = 'exp-billing-analysis')
+    experiment_id = 'exp-billing-analysis'
 LIMIT 1 BY input_id
         """
         result = await query_fn(query_str)
@@ -748,7 +710,6 @@ class TestAddCompletionToExperiment:
         experiment = fake_experiment(
             id="test-experiment-123",
             agent_id="test-agent",
-            run_ids=[],  # Start with empty run_ids
         )
 
         # Store the experiment first
@@ -758,7 +719,7 @@ class TestAddCompletionToExperiment:
         completion_id = uuid7(ms=lambda: 0, rand=lambda: 1)
 
         # Add completion to experiment
-        await client.add_completion_to_experiment("test-experiment-123", completion_id, {"mutations_sync": 1})
+        await client.add_completions_to_experiment("test-experiment-123", [completion_id], {"mutations_sync": 1})
 
         # Verify the completion was added by querying the database
         result = await client._client.query(
@@ -784,14 +745,16 @@ class TestAddCompletionToExperiment:
         experiment = fake_experiment(
             id="test-experiment-456",
             agent_id="test-agent",
-            run_ids=[str(completion_id)],  # Start with one completion
         )
 
         # Store the experiment first
         await client.store_experiment(experiment, _insert_settings)
 
-        # Add the same completion ID again
-        await client.add_completion_to_experiment("test-experiment-456", completion_id, {"mutations_sync": 1})
+        # Add a completion id
+        await client.add_completions_to_experiment("test-experiment-456", [completion_id], {"mutations_sync": 1})
+
+        # Add it again
+        await client.add_completions_to_experiment("test-experiment-456", [completion_id], {"mutations_sync": 1})
 
         # Verify there's still only one instance of the completion ID
         result = await client._client.query(

--- a/backend/core/storage/clickhouse/migrations/4_experiment_id.sql
+++ b/backend/core/storage/clickhouse/migrations/4_experiment_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE completions
+ADD COLUMN experiment_id String ALIAS metadata ['anotherai/experiment_id'];
+-- Add description to field experiment_id field
+ALTER TABLE completions
+MODIFY COLUMN experiment_id String COMMENT 'The ID of the experiment that this completion belongs to. Mapping to metadata field anotherai/experiment_id.';
+ALTER TABLE experiments DROP COLUMN completion_ids;

--- a/backend/core/storage/completion_storage.py
+++ b/backend/core/storage/completion_storage.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from typing import Any, Literal, Protocol
 from uuid import UUID
 
@@ -16,7 +17,7 @@ class CompletionStorage(Protocol):
 
     async def store_experiment(self, experiment: Experiment): ...
 
-    async def add_completion_to_experiment(self, experiment_id: str, completion_id: UUID): ...
+    async def add_completions_to_experiment(self, experiment_id: str, completion_ids: Collection[UUID]): ...
 
     async def completions_by_ids(
         self,

--- a/backend/core/storage/experiment_storage.py
+++ b/backend/core/storage/experiment_storage.py
@@ -37,9 +37,6 @@ class ExperimentStorage(Protocol):
 
     async def set_result(self, experiment_id: str, result: str) -> None: ...
 
-    # TODO: deprecate
-    async def add_run_id(self, experiment_id: str, run_id: UUID) -> None: ...
-
     async def delete(self, experiment_id: str) -> None: ...
 
     async def list_experiments(

--- a/backend/core/storage/psql/migrations/3_experiments.sql
+++ b/backend/core/storage/psql/migrations/3_experiments.sql
@@ -10,7 +10,7 @@ CREATE TABLE experiments (
     title TEXT NOT NULL,
     description TEXT NOT NULL,
     result TEXT,
-    run_ids VARCHAR(64) [] NOT NULL,
+    run_ids VARCHAR(64) [],
     metadata JSONB NOT NULL,
     CONSTRAINT experiments_tenant_uid_slug_unique UNIQUE (tenant_uid, slug)
 );

--- a/backend/core/storage/psql/psql_annotation_storage_test.py
+++ b/backend/core/storage/psql/psql_annotation_storage_test.py
@@ -26,7 +26,6 @@ async def test_experiment(experiment_storage: PsqlExperimentStorage, test_agent:
     experiment = fake_experiment(
         id=f"test-experiment-{uuid.uuid4().hex[:8]}",
         agent_id=test_agent.id,
-        run_ids=["00000000-0000-0007-0000-000000000001"],
     )
     await experiment_storage.create(experiment)
     return experiment

--- a/backend/core/storage/psql/psql_experiment_storage.py
+++ b/backend/core/storage/psql/psql_experiment_storage.py
@@ -6,7 +6,6 @@ from uuid import UUID
 import asyncpg
 import structlog
 from asyncpg.pool import PoolConnectionProxy
-from pydantic import Field
 
 from core.domain.agent_output import AgentOutput
 from core.domain.cache_usage import CacheUsage
@@ -625,8 +624,6 @@ class _ExperimentRow(AgentLinkedRow, WithUpdatedAtRow):
     result: str | None = None
     metadata: JSONDict | None = None
     use_cache: str | None = None
-
-    run_ids: list[str] = Field(default_factory=list, deprecated="Should not be used anymore")
 
     def _use_cache_to_domain(self) -> CacheUsage | None:
         if self.use_cache is None:

--- a/backend/protocol/api/_services/experiment_service.py
+++ b/backend/protocol/api/_services/experiment_service.py
@@ -2,14 +2,13 @@ import asyncio
 import time
 from collections.abc import Collection
 from typing import Any, Literal, cast, final
-from uuid import UUID
 
 from core.domain.agent import Agent
 from core.domain.annotation import Annotation
 from core.domain.cache_usage import CacheUsage
 from core.domain.exceptions import ObjectNotFoundError
 from core.storage.agent_storage import AgentStorage
-from core.storage.annotation_storage import AnnotationStorage, TargetFilter
+from core.storage.annotation_storage import AnnotationStorage
 from core.storage.completion_storage import CompletionStorage
 from core.storage.experiment_storage import ExperimentFields, ExperimentStorage
 from core.utils.background import add_background_task
@@ -87,12 +86,8 @@ class ExperimentService:
 
         annotations: list[Annotation] = []
         if include is None or "annotations" in include:
-            annotations = await self.annotation_storage.list(
-                target=TargetFilter(completion_id={UUID(run_id) for run_id in exp.run_ids}),
-                context=None,
-                since=None,
-                limit=100,
-            )
+            # TODO: get annotations for the experiment
+            annotations = []
 
         # getting annotations as needed
         return experiment_from_domain(exp, annotations)

--- a/backend/tests/fake_models.py
+++ b/backend/tests/fake_models.py
@@ -181,7 +181,6 @@ def fake_experiment(**kwargs: Any):
         description="A test experiment",
         result=None,
         agent_id="test-agent",
-        run_ids=[],
         metadata={"key": "value"},
     )
     return Experiment.model_validate(

--- a/backend/tests/fixtures/clickhouse/annotations.json
+++ b/backend/tests/fixtures/clickhouse/annotations.json
@@ -1,146 +1,110 @@
 [
   {
-    "id": "ann-001",
+    "tenant_uid": 1,
     "created_at": "2025-01-20T10:30:00Z",
+    "id": "ann-001",
     "updated_at": "2025-01-20T10:30:00Z",
-    "author_name": "data_analyst",
-    "target": {
-      "completion_id": "01933b7c-b2a1-7000-8000-000000000001",
-      "experiment_id": "exp-billing-analysis",
-      "key_path": "response.solution"
-    },
-    "context": {
-      "agent_id": "customer-support-agent",
-      "experiment_id": "exp-billing-analysis"
-    },
+    "agent_id": "customer-support-agent",
+    "completion_id": "01933b7c-b2a1-7000-8000-000000000001",
     "text": "Excellent resolution - correctly identified billing error and initiated refund",
-    "metric": {
-      "name": "quality_score",
-      "value": 9.2
-    },
+    "metric_name": "quality_score",
+    "metric_value_float": 9.2,
+    "metric_value_str": null,
+    "metric_value_bool": null,
     "metadata": {
       "category": "billing",
       "reviewer_confidence": "high"
-    }
+    },
+    "author_name": "data_analyst"
   },
   {
-    "id": "ann-002",
+    "tenant_uid": 1,
     "created_at": "2025-01-20T14:15:00Z",
+    "id": "ann-002",
     "updated_at": "2025-01-20T14:15:00Z",
-    "author_name": "code_reviewer",
-    "target": {
-      "completion_id": "01933b7c-b2a1-7000-8000-000000000002",
-      "experiment_id": "exp-code-quality",
-      "key_path": "response.suggestions"
-    },
-    "context": {
-      "agent_id": "code-review-agent",
-      "experiment_id": "exp-code-quality"
-    },
+    "agent_id": "code-review-agent",
+    "completion_id": "01933b7c-b2a1-7000-8000-000000000002",
     "text": "Code review caught important security vulnerability",
-    "metric": {
-      "name": "security_impact",
-      "value": "high"
-    },
+    "metric_name": "security_impact",
+    "metric_value_float": null,
+    "metric_value_str": "high",
+    "metric_value_bool": null,
     "metadata": {
       "vulnerability_type": "sql_injection",
       "severity": "critical"
-    }
+    },
+    "author_name": "code_reviewer"
   },
   {
-    "id": "ann-003",
+    "tenant_uid": 1,
     "created_at": "2025-01-20T16:45:00Z",
+    "id": "ann-003",
     "updated_at": "2025-01-20T16:45:00Z",
-    "author_name": "data_analyst",
-    "target": {
-      "completion_id": "01933b7c-b2a1-7000-8000-000000000003",
-      "experiment_id": "exp-data-analysis",
-      "key_path": "response.insights"
-    },
-    "context": {
-      "agent_id": "data-analysis-agent",
-      "experiment_id": "exp-data-analysis"
-    },
+    "agent_id": "data-analysis-agent",
+    "completion_id": "01933b7c-b2a1-7000-8000-000000000003",
     "text": "Data analysis identified key trends but missed seasonal patterns",
-    "metric": {
-      "name": "accuracy",
-      "value": 7.8
-    },
+    "metric_name": "accuracy",
+    "metric_value_float": 7.8,
+    "metric_value_str": null,
+    "metric_value_bool": null,
     "metadata": {
       "analysis_type": "trend_analysis",
       "data_quality": "good"
-    }
+    },
+    "author_name": "data_analyst"
   },
   {
-    "id": "ann-004",
+    "tenant_uid": 1,
     "created_at": "2025-01-19T09:00:00Z",
+    "id": "ann-004",
     "updated_at": "2025-01-19T09:00:00Z",
-    "author_name": "user_feedback_bot",
-    "target": {
-      "completion_id": "01933b7c-b2a1-7000-8000-000000000001",
-      "experiment_id": null,
-      "key_path": null
-    },
-    "context": {
-      "agent_id": "customer-support-agent",
-      "experiment_id": null
-    },
+    "agent_id": "customer-support-agent",
+    "completion_id": "01933b7c-b2a1-7000-8000-000000000001",
     "text": "Customer reported satisfaction with billing resolution",
-    "metric": {
-      "name": "user_feedback",
-      "value": true
-    },
+    "metric_name": "user_feedback",
+    "metric_value_float": null,
+    "metric_value_str": null,
+    "metric_value_bool": true,
     "metadata": {
       "feedback_source": "survey",
       "response_time": "24h"
-    }
+    },
+    "author_name": "user_feedback_bot"
   },
   {
-    "id": "ann-005",
+    "tenant_uid": 1,
     "created_at": "2025-01-20T11:30:00Z",
+    "id": "ann-005",
     "updated_at": "2025-01-20T11:30:00Z",
-    "author_name": "performance_monitor",
-    "target": {
-      "completion_id": "01933b7c-b2a1-7000-8000-000000000002",
-      "experiment_id": "exp-code-quality",
-      "key_path": "response.execution_time"
-    },
-    "context": {
-      "agent_id": "code-review-agent",
-      "experiment_id": "exp-code-quality"
-    },
+    "agent_id": "code-review-agent",
+    "completion_id": "01933b7c-b2a1-7000-8000-000000000002",
     "text": "Response time within acceptable range",
-    "metric": {
-      "name": "response_time_ms",
-      "value": 3400.0
-    },
+    "metric_name": "response_time_ms",
+    "metric_value_float": 3400,
+    "metric_value_str": null,
+    "metric_value_bool": null,
     "metadata": {
       "threshold": "5000ms",
       "performance_tier": "acceptable"
-    }
+    },
+    "author_name": "performance_monitor"
   },
   {
-    "id": "ann-006",
+    "tenant_uid": 1,
     "created_at": "2025-01-20T18:00:00Z",
+    "id": "ann-006",
     "updated_at": "2025-01-20T18:00:00Z",
-    "author_name": "quality_assurance",
-    "target": {
-      "completion_id": "01933b7c-b2a1-7000-8000-000000000003",
-      "experiment_id": "exp-data-analysis",
-      "key_path": "response.methodology"
-    },
-    "context": {
-      "agent_id": "data-analysis-agent",
-      "experiment_id": "exp-data-analysis"
-    },
+    "agent_id": "data-analysis-agent",
+    "completion_id": "01933b7c-b2a1-7000-8000-000000000003",
     "text": "Methodology is sound but could benefit from additional validation steps",
-    "metric": {
-      "name": "methodology_score",
-      "value": 8.1
-    },
+    "metric_name": "methodology_score",
+    "metric_value_float": 8.1,
+    "metric_value_str": null,
+    "metric_value_bool": null,
     "metadata": {
       "review_type": "methodology",
       "improvement_potential": "medium"
-    }
+    },
+    "author_name": "quality_assurance"
   }
 ]

--- a/backend/tests/fixtures/clickhouse/completions.json
+++ b/backend/tests/fixtures/clickhouse/completions.json
@@ -1,323 +1,121 @@
 [
   {
+    "tenant_uid": 1,
+    "agent_id": "customer-support-agent",
     "id": "01933b7c-b2a1-7000-8000-000000000001",
-    "agent": {
-      "uid": 101,
-      "id": "customer-support-agent",
-      "name": "Customer Support Agent",
-      "created_at": "2025-01-20T10:00:00Z"
+    "updated_at": "2024-11-17T18:57:28.225000Z",
+    "version_id": "ad9568474746437dbe7f9f0cc9d6a5a0",
+    "version_model": "gpt-4o-mini",
+    "version": "{\"id\":\"ad9568474746437dbe7f9f0cc9d6a5a0\",\"model\":\"gpt-4o-mini\",\"provider\":\"openai\",\"temperature\":0.3,\"max_output_tokens\":500,\"use_structured_generation\":false,\"prompt\":[{\"role\":\"system\",\"content\":[{\"text\":\"You are a customer support agent for {{customer_name}}.\"}]}]}",
+    "input_id": "f0f00f31c1c9358090cc6f36685a9b9d",
+    "input_preview": "Customer inquiry about billing",
+    "input_messages": "[{\"role\":\"user\",\"content\":[{\"text\":\"Hi, I have a billing issue with my account.\"}]}]",
+    "input_variables": "{\"customer_name\":\"Alice Johnson\",\"ticket_id\":\"BILL-2025-001\"}",
+    "output_id": "96611af897a1138b7dd92a14d8df06ad",
+    "output_preview": "Billing issue resolution",
+    "output_messages": "[{\"role\":\"assistant\",\"content\":[{\"text\":\"I apologize for the billing error. I've initiated a refund for $29.99.\"}]}]",
+    "output_error": "",
+    "messages": "[{\"role\":\"system\",\"content\":[{\"text\":\"You are a customer support agent for {{customer_name}}.\"}]},{\"role\":\"user\",\"content\":[{\"text\":\"Hi, I have a billing issue with my account.\"}]}]",
+    "duration_ds": 22,
+    "cost_millionth_usd": 4500,
+    "metadata": {
+      "user_id": "user_001",
+      "department": "customer_support",
+      "priority": "high",
+      "anotherai/experiment_id": "exp-billing-analysis"
     },
-    "agent_input": {
-      "preview": "Customer inquiry about billing",
-      "variables": {
-        "customer_name": "Alice Johnson",
-        "ticket_id": "BILL-2025-001"
-      },
-      "messages": [
-        {
-          "role": "user",
-          "content": [
-            {
-              "text": "Hi, I have a billing issue with my account."
-            }
-          ]
-        }
-      ]
-    },
-    "agent_output": {
-      "preview": "Billing issue resolution",
-      "messages": [
-        {
-          "role": "assistant",
-          "content": [
-            {
-              "text": "I apologize for the billing error. I've initiated a refund for $29.99."
-            }
-          ]
-        }
-      ],
-      "error": null
-    },
-    "messages": [
-      {
-        "role": "system",
-        "content": [
-          {
-            "text": "You are a customer support agent for {{customer_name}}."
-          }
-        ]
-      },
-      {
-        "role": "user",
-        "content": [
-          {
-            "text": "Hi, I have a billing issue with my account."
-          }
-        ]
-      }
-    ],
-    "version": {
-      "model": "gpt-4o-mini",
-      "provider": "openai",
-      "temperature": 0.3,
-      "max_output_tokens": 500,
-      "use_structured_generation": false,
-      "tool_choice": null,
-      "prompt": [
-        {
-          "role": "system",
-          "content": [
-            {
-              "text": "You are a customer support agent for {{customer_name}}."
-            }
-          ]
-        }
-      ]
-    },
-    "status": "success",
-    "duration_seconds": 2.15,
-    "cost_usd": 0.0045,
-    "created_at": "2025-01-20T10:30:00Z",
+    "source": "api",
     "traces": [
       {
         "kind": "llm",
         "model": "gpt-4o-mini",
         "provider": "openai",
-        "duration_seconds": 2.15,
-        "cost_usd": 0.0045,
-        "usage": {
-          "prompt": {
-            "cached_token_count": 0,
-            "reasoning_token_count": 0,
-            "cost_usd": 0.002
-          },
-          "completion": {
-            "text_token_count": 95,
-            "cost_usd": 0.0025
-          }
-        }
+        "usage": "{\"prompt\":{\"cost_usd\":0.002},\"completion\":{\"text_token_count\":95.0,\"cost_usd\":0.0025}}",
+        "name": "",
+        "tool_input_preview": "",
+        "tool_output_preview": "",
+        "duration_ds": 22,
+        "cost_millionth_usd": 4500
       }
-    ],
-    "from_cache": false,
-    "source": "api",
-    "metadata": {
-      "user_id": "user_001",
-      "department": "customer_support",
-      "priority": "high"
-    }
+    ]
   },
   {
+    "tenant_uid": 1,
+    "agent_id": "code-review-agent",
     "id": "01933b7c-b2a1-7000-8000-000000000002",
-    "agent": {
-      "uid": 102,
-      "id": "code-review-agent",
-      "name": "Code Review Agent",
-      "created_at": "2025-01-20T10:30:00Z"
+    "updated_at": "2024-11-17T18:57:28.225000Z",
+    "version_id": "741ba66142d34816f0b2e10b4ffc3b48",
+    "version_model": "gpt-4o",
+    "version": "{\"id\":\"741ba66142d34816f0b2e10b4ffc3b48\",\"model\":\"gpt-4o\",\"provider\":\"openai\",\"temperature\":0.1,\"max_output_tokens\":800,\"use_structured_generation\":false,\"prompt\":[{\"role\":\"system\",\"content\":[{\"text\":\"You are a software engineer providing code reviews for {{language}}.\"}]}]}",
+    "input_id": "125ab480f2f2b526a7e7fc60e97b9221",
+    "input_preview": "Python code review",
+    "input_messages": "[{\"role\":\"user\",\"content\":[{\"text\":\"Please review this Python function.\"}]}]",
+    "input_variables": "{\"language\":\"python\",\"file_name\":\"data_processor.py\"}",
+    "output_id": "2b75bcc59be450de6b1b82bb918cad33",
+    "output_preview": "Code review with suggestions",
+    "output_messages": "[{\"role\":\"assistant\",\"content\":[{\"text\":\"I've reviewed your Python function and found several improvements.\"}]}]",
+    "output_error": "",
+    "messages": "[{\"role\":\"system\",\"content\":[{\"text\":\"You are a software engineer providing code reviews for {{language}}.\"}]},{\"role\":\"user\",\"content\":[{\"text\":\"Please review this Python function.\"}]}]",
+    "duration_ds": 34,
+    "cost_millionth_usd": 12000,
+    "metadata": {
+      "user_id": "dev_002",
+      "department": "engineering",
+      "priority": "medium",
+      "anotherai/experiment_id": "exp-code-quality"
     },
-    "agent_input": {
-      "preview": "Python code review",
-      "variables": {
-        "language": "python",
-        "file_name": "data_processor.py"
-      },
-      "messages": [
-        {
-          "role": "user",
-          "content": [
-            {
-              "text": "Please review this Python function."
-            }
-          ]
-        }
-      ]
-    },
-    "agent_output": {
-      "preview": "Code review with suggestions",
-      "messages": [
-        {
-          "role": "assistant",
-          "content": [
-            {
-              "text": "I've reviewed your Python function and found several improvements."
-            }
-          ]
-        }
-      ],
-      "error": null
-    },
-    "messages": [
-      {
-        "role": "system",
-        "content": [
-          {
-            "text": "You are a software engineer providing code reviews for {{language}}."
-          }
-        ]
-      },
-      {
-        "role": "user",
-        "content": [
-          {
-            "text": "Please review this Python function."
-          }
-        ]
-      }
-    ],
-    "version": {
-      "model": "gpt-4o",
-      "provider": "openai",
-      "temperature": 0.1,
-      "max_output_tokens": 800,
-      "use_structured_generation": false,
-      "tool_choice": null,
-      "prompt": [
-        {
-          "role": "system",
-          "content": [
-            {
-              "text": "You are a software engineer providing code reviews for {{language}}."
-            }
-          ]
-        }
-      ]
-    },
-    "status": "success",
-    "duration_seconds": 3.42,
-    "cost_usd": 0.012,
-    "created_at": "2025-01-20T11:15:00Z",
+    "source": "api",
     "traces": [
       {
         "kind": "llm",
         "model": "gpt-4o",
         "provider": "openai",
-        "duration_seconds": 3.42,
-        "cost_usd": 0.012,
-        "usage": {
-          "prompt": {
-            "cached_token_count": 0,
-            "reasoning_token_count": 0,
-            "cost_usd": 0.005
-          },
-          "completion": {
-            "text_token_count": 280,
-            "cost_usd": 0.007
-          }
-        }
+        "usage": "{\"prompt\":{\"cost_usd\":0.005},\"completion\":{\"text_token_count\":280.0,\"cost_usd\":0.007}}",
+        "name": "",
+        "tool_input_preview": "",
+        "tool_output_preview": "",
+        "duration_ds": 34,
+        "cost_millionth_usd": 12000
       }
-    ],
-    "from_cache": false,
-    "source": "api",
-    "metadata": {
-      "user_id": "dev_002",
-      "department": "engineering",
-      "priority": "medium"
-    }
+    ]
   },
   {
+    "tenant_uid": 1,
+    "agent_id": "data-analysis-agent",
     "id": "01933b7c-b2a1-7000-8000-000000000003",
-    "agent": {
-      "uid": 103,
-      "id": "data-analysis-agent",
-      "name": "Data Analysis Agent",
-      "created_at": "2025-01-20T09:00:00Z"
+    "updated_at": "2024-11-17T18:57:28.225000Z",
+    "version_id": "836bd2b5b94c28547eefac31d9142550",
+    "version_model": "claude-3-5-sonnet-20241022",
+    "version": "{\"id\":\"836bd2b5b94c28547eefac31d9142550\",\"model\":\"claude-3-5-sonnet-20241022\",\"provider\":\"anthropic\",\"temperature\":0.7,\"max_output_tokens\":1000,\"use_structured_generation\":false,\"prompt\":[{\"role\":\"system\",\"content\":[{\"text\":\"You are a data analyst analyzing {{quarter}} {{metric}} performance.\"}]}]}",
+    "input_id": "d7e405221518da0a060c1c636979d412",
+    "input_preview": "Q4 sales analysis",
+    "input_messages": "[{\"role\":\"user\",\"content\":[{\"text\":\"Analyze Q4 2024 sales data and provide insights.\"}]}]",
+    "input_variables": "{\"quarter\":\"Q4 2024\",\"metric\":\"revenue\"}",
+    "output_id": "9a8ae5ceaa50470d9298d6d8e6b7fd0b",
+    "output_preview": "Q4 2024 sales report",
+    "output_messages": "[{\"role\":\"assistant\",\"content\":[{\"text\":\"Q4 2024 Revenue: $2.4M (+15% YoY). Key insight: Enterprise segment drove 65% of growth.\"}]}]",
+    "output_error": "",
+    "messages": "[{\"role\":\"system\",\"content\":[{\"text\":\"You are a data analyst analyzing {{quarter}} {{metric}} performance.\"}]},{\"role\":\"user\",\"content\":[{\"text\":\"Analyze Q4 2024 sales data and provide insights.\"}]}]",
+    "duration_ds": 48,
+    "cost_millionth_usd": 25000,
+    "metadata": {
+      "user_id": "analyst_003",
+      "department": "business_intelligence",
+      "priority": "high"
     },
-    "agent_input": {
-      "preview": "Q4 sales analysis",
-      "variables": {
-        "quarter": "Q4 2024",
-        "metric": "revenue"
-      },
-      "messages": [
-        {
-          "role": "user",
-          "content": [
-            {
-              "text": "Analyze Q4 2024 sales data and provide insights."
-            }
-          ]
-        }
-      ]
-    },
-    "agent_output": {
-      "preview": "Q4 2024 sales report",
-      "messages": [
-        {
-          "role": "assistant",
-          "content": [
-            {
-              "text": "Q4 2024 Revenue: $2.4M (+15% YoY). Key insight: Enterprise segment drove 65% of growth."
-            }
-          ]
-        }
-      ],
-      "error": null
-    },
-    "messages": [
-      {
-        "role": "system",
-        "content": [
-          {
-            "text": "You are a data analyst analyzing {{quarter}} {{metric}} performance."
-          }
-        ]
-      },
-      {
-        "role": "user",
-        "content": [
-          {
-            "text": "Analyze Q4 2024 sales data and provide insights."
-          }
-        ]
-      }
-    ],
-    "version": {
-      "model": "claude-3-5-sonnet-20241022",
-      "provider": "anthropic",
-      "temperature": 0.7,
-      "max_output_tokens": 1000,
-      "use_structured_generation": false,
-      "tool_choice": null,
-      "prompt": [
-        {
-          "role": "system",
-          "content": [
-            {
-              "text": "You are a data analyst analyzing {{quarter}} {{metric}} performance."
-            }
-          ]
-        }
-      ]
-    },
-    "status": "success",
-    "duration_seconds": 4.78,
-    "cost_usd": 0.025,
-    "created_at": "2025-01-20T14:22:00Z",
+    "source": "web",
     "traces": [
       {
         "kind": "llm",
         "model": "claude-3-5-sonnet-20241022",
         "provider": "anthropic",
-        "duration_seconds": 4.78,
-        "cost_usd": 0.025,
-        "usage": {
-          "prompt": {
-            "cached_token_count": 0,
-            "reasoning_token_count": 0,
-            "cost_usd": 0.008
-          },
-          "completion": {
-            "text_token_count": 385,
-            "cost_usd": 0.017
-          }
-        }
+        "usage": "{\"prompt\":{\"cost_usd\":0.008},\"completion\":{\"text_token_count\":385.0,\"cost_usd\":0.017}}",
+        "name": "",
+        "tool_input_preview": "",
+        "tool_output_preview": "",
+        "duration_ds": 48,
+        "cost_millionth_usd": 25000
       }
-    ],
-    "from_cache": false,
-    "source": "web",
-    "metadata": {
-      "user_id": "analyst_003",
-      "department": "business_intelligence",
-      "priority": "high"
-    }
+    ]
   }
 ]

--- a/backend/tests/fixtures/clickhouse/experiments.json
+++ b/backend/tests/fixtures/clickhouse/experiments.json
@@ -1,15 +1,12 @@
 [
   {
-    "id": "exp-billing-analysis",
+    "tenant_uid": 1,
     "created_at": "2025-01-20T09:00:00Z",
-    "updated_at": "2025-01-20T17:00:00Z",
-    "author_name": "experiment_manager",
+    "id": "exp-billing-analysis",
     "title": "Billing Issue Resolution Analysis",
     "description": "Analyzing how well the customer support agent handles billing-related inquiries",
     "result": "Agent successfully resolved 85% of billing issues with high customer satisfaction",
     "agent_id": "customer-support-agent",
-    "run_ids": ["01933b7c-b2a1-7000-8000-000000000001"],
-    "annotations": [],
     "metadata": {
       "experiment_type": "performance_analysis",
       "duration_days": "7",
@@ -17,16 +14,13 @@
     }
   },
   {
-    "id": "exp-code-quality",
+    "tenant_uid": 1,
     "created_at": "2025-01-20T08:00:00Z",
-    "updated_at": "2025-01-20T16:00:00Z",
-    "author_name": "engineering_lead",
+    "id": "exp-code-quality",
     "title": "Code Review Quality Assessment",
     "description": "Evaluating the effectiveness of AI-powered code review suggestions",
     "result": "Code review agent identified 92% of security vulnerabilities and 78% of performance issues",
     "agent_id": "code-review-agent",
-    "run_ids": ["01933b7c-b2a1-7000-8000-000000000002"],
-    "annotations": [],
     "metadata": {
       "experiment_type": "quality_assessment",
       "code_samples": "500",
@@ -34,16 +28,13 @@
     }
   },
   {
-    "id": "exp-data-analysis",
+    "tenant_uid": 1,
     "created_at": "2025-01-20T07:00:00Z",
-    "updated_at": "2025-01-20T19:00:00Z",
-    "author_name": "data_science_team",
+    "id": "exp-data-analysis",
     "title": "Data Analysis Accuracy Experiment",
     "description": "Testing the accuracy of data analysis and trend identification capabilities",
     "result": null,
     "agent_id": "data-analysis-agent",
-    "run_ids": ["01933b7c-b2a1-7000-8000-000000000003"],
-    "annotations": [],
     "metadata": {
       "experiment_type": "accuracy_testing",
       "dataset_size": "10000",
@@ -51,20 +42,13 @@
     }
   },
   {
-    "id": "exp-multi-agent-comparison",
+    "tenant_uid": 1,
     "created_at": "2025-01-19T10:00:00Z",
-    "updated_at": "2025-01-20T20:00:00Z",
-    "author_name": "research_team",
+    "id": "exp-multi-agent-comparison",
     "title": "Multi-Agent Performance Comparison",
     "description": "Comparing performance across different agent types on similar tasks",
     "result": "Customer support agent showed highest user satisfaction, code review agent had best accuracy on technical tasks",
     "agent_id": "multi-agent-comparison",
-    "run_ids": [
-      "01933b7c-b2a1-7000-8000-000000000001",
-      "01933b7c-b2a1-7000-8000-000000000002",
-      "01933b7c-b2a1-7000-8000-000000000003"
-    ],
-    "annotations": [],
     "metadata": {
       "experiment_type": "comparative_analysis",
       "agents_tested": "3",


### PR DESCRIPTION
- [x] remove deprecated run_ids
- [x] add experiment_id alias to make it easier to group runs by experiment_id. It's all good since we now store cached runs so each run is at most in an experiment_id
- [ ] fix returned annotations when fetching experiments
- [ ] test experiment_id correctly added and raw query is possible
- [ ] test all annotations are returned when fetching an experiment