### PR TITLE
[GitHub-450] Delete button for annotations is unresponsive

### DIFF
--- a/backend/core/storage/psql/psql_annotation_storage.py
+++ b/backend/core/storage/psql/psql_annotation_storage.py
@@ -167,7 +167,7 @@ class PsqlAnnotationStorage(PsqlBaseStorage, AnnotationStorage):
                 """
                 UPDATE annotations
                 SET deleted_at = CURRENT_TIMESTAMP
-                WHERE slug = $2
+                WHERE slug = $1
                 """,
                 annotation_id,
             )


### PR DESCRIPTION
### Closes:
https://github.com/anotherai-dev/anotherai/issues/450

@anyacherniss @guillaq 
Looks like this issue is on backend.
It's a simple one so I made this PR with it.

@guillaq  Could you review and see if this change is ok with you?